### PR TITLE
update osm-lib to make intersection detection take less memory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>osm-lib</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
this solves problems with the server running out of memory while loading large OSM files