### PR TITLE
Add JSON error messages to every halt

### DIFF
--- a/src/main/java/com/conveyal/taui/TransportAnalyst.java
+++ b/src/main/java/com/conveyal/taui/TransportAnalyst.java
@@ -4,7 +4,15 @@ import com.auth0.jwt.JWTVerifier;
 import com.conveyal.gtfs.GTFSCache;
 import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.taui.analysis.LocalCluster;
-import com.conveyal.taui.controllers.*;
+import com.conveyal.taui.controllers.AggregationAreaController;
+import com.conveyal.taui.controllers.BundleController;
+import com.conveyal.taui.controllers.GraphQLController;
+import com.conveyal.taui.controllers.GridController;
+import com.conveyal.taui.controllers.ModificationController;
+import com.conveyal.taui.controllers.ProjectController;
+import com.conveyal.taui.controllers.RegionalAnalysisController;
+import com.conveyal.taui.controllers.ScenarioController;
+import com.conveyal.taui.controllers.SinglePointAnalysisController;
 import com.conveyal.taui.persistence.OSMPersistence;
 import com.conveyal.taui.persistence.Persistence;
 import com.google.common.io.CharStreams;
@@ -20,7 +28,9 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 import static com.conveyal.taui.util.SparkUtil.haltWithJson;
-import static spark.Spark.*;
+import static spark.Spark.before;
+import static spark.Spark.get;
+import static spark.Spark.port;
 
 /**
  * Main entry point

--- a/src/main/java/com/conveyal/taui/TransportAnalyst.java
+++ b/src/main/java/com/conveyal/taui/TransportAnalyst.java
@@ -4,15 +4,7 @@ import com.auth0.jwt.JWTVerifier;
 import com.conveyal.gtfs.GTFSCache;
 import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.taui.analysis.LocalCluster;
-import com.conveyal.taui.controllers.AggregationAreaController;
-import com.conveyal.taui.controllers.SinglePointAnalysisController;
-import com.conveyal.taui.controllers.BundleController;
-import com.conveyal.taui.controllers.GraphQLController;
-import com.conveyal.taui.controllers.GridController;
-import com.conveyal.taui.controllers.ModificationController;
-import com.conveyal.taui.controllers.ProjectController;
-import com.conveyal.taui.controllers.RegionalAnalysisController;
-import com.conveyal.taui.controllers.ScenarioController;
+import com.conveyal.taui.controllers.*;
 import com.conveyal.taui.persistence.OSMPersistence;
 import com.conveyal.taui.persistence.Persistence;
 import com.google.common.io.CharStreams;
@@ -27,10 +19,8 @@ import java.io.InputStreamReader;
 import java.time.LocalDateTime;
 import java.util.Map;
 
-import static spark.Spark.before;
-import static spark.Spark.get;
-import static spark.Spark.halt;
-import static spark.Spark.port;
+import static com.conveyal.taui.util.SparkUtil.haltWithJson;
+import static spark.Spark.*;
 
 /**
  * Main entry point
@@ -71,12 +61,16 @@ public class TransportAnalyst {
                 String auth = req.headers("Authorization");
 
                 // authorization required
-                if (auth == null || auth.isEmpty()) halt(401);
+                if (auth == null || auth.isEmpty()) {
+                    haltWithJson(401, "You must be logged in.");
+                }
 
                 // make sure it's properly formed
                 String[] authComponents = auth.split(" ");
 
-                if (authComponents.length != 2 || !"bearer".equals(authComponents[0].toLowerCase())) halt(400);
+                if (authComponents.length != 2 || !"bearer".equals(authComponents[0].toLowerCase())) {
+                    haltWithJson(400, "Authorization header is malformed: " + auth);
+                }
 
                 // validate the JWT
                 JWTVerifier verifier = new JWTVerifier(auth0Secret, auth0ClientId);
@@ -86,21 +80,21 @@ public class TransportAnalyst {
                     jwt = verifier.verify(authComponents[1]);
                 } catch (Exception e) {
                     LOG.info("Login failed", e);
-                    halt(403);
+                    haltWithJson(403, "Login failed to verify with our authorization provider.");
                 }
 
                 if (!jwt.containsKey("analyst")) {
-                    halt(403);
+                    haltWithJson(403, "Access denied. User does not have access to Analysis.");
                 }
 
                 String group = null;
                 try {
                     group = (String) ((Map<String, Object>) jwt.get("analyst")).get("group");
                 } catch (Exception e) {
-                    halt(403);
+                    haltWithJson(403, "Access denied. User is not associated with any group.");
                 }
 
-                if (group == null) halt(403);
+                if (group == null) haltWithJson(403, "Access denied. User is not associated with any group.");
 
                 req.attribute("group", group);
             } else {

--- a/src/main/java/com/conveyal/taui/controllers/AggregationAreaController.java
+++ b/src/main/java/com/conveyal/taui/controllers/AggregationAreaController.java
@@ -28,7 +28,13 @@ import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/com/conveyal/taui/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BundleController.java
@@ -121,6 +121,11 @@ public class BundleController {
                             Persistence.bundles.put(finalBundle.id, finalBundle);
                             return fs;
                         } catch (Exception e) {
+                            // This catches any error while processing a feed with the GTFS Api and needs to be more
+                            // robust in bubbling up the specific errors to the UI. Really, we need to separate out the
+                            // idea of bundles, track uploads of single feeds at a time, and allow the creation of a
+                            // "bundle" at a later point. This updated error handling is a stopgap until we improve that
+                            // flow.
                             finalBundle.status = Bundle.Status.ERROR;
                             finalBundle.errorCode = e.getMessage();
                             Persistence.bundles.put(bundleId, finalBundle);

--- a/src/main/java/com/conveyal/taui/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BundleController.java
@@ -24,11 +24,20 @@ import spark.Response;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.conveyal.taui.util.SparkUtil.haltWithJson;
-import static spark.Spark.*;
+import static spark.Spark.delete;
+import static spark.Spark.get;
+import static spark.Spark.post;
+import static spark.Spark.put;
 
 /**
  * Created by matthewc on 3/14/16.

--- a/src/main/java/com/conveyal/taui/controllers/GraphQLController.java
+++ b/src/main/java/com/conveyal/taui/controllers/GraphQLController.java
@@ -145,10 +145,12 @@ public class GraphQLController {
 
         return bundle.feeds.stream()
                 .map(summary -> {
-                    FeedSource fs = ApiMain.getFeedSource(summary.bundleScopedFeedId);
+                    String bundleScopedFeedId = summary.bundleScopedFeedId == null
+                        ? String.format("%s_%s", summary.feedId, bundle.id) : summary.bundleScopedFeedId;
+                    FeedSource fs = ApiMain.getFeedSource(bundleScopedFeedId);
 
                     FeedInfo ret;
-                    if (fs.feed.feedInfo.size() > 0) ret = fs.feed.feedInfo.values().iterator().next();
+                    if (fs != null && fs.feed.feedInfo.size() > 0) ret = fs.feed.feedInfo.values().iterator().next();
                     else {
                         ret = new FeedInfo();
                     }

--- a/src/main/java/com/conveyal/taui/controllers/GridController.java
+++ b/src/main/java/com/conveyal/taui/controllers/GridController.java
@@ -26,11 +26,17 @@ import spark.Response;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.conveyal.taui.util.SparkUtil.haltWithJson;
-import static spark.Spark.*;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 /**
  * Controller that handles fetching grids.

--- a/src/main/java/com/conveyal/taui/controllers/GridController.java
+++ b/src/main/java/com/conveyal/taui/controllers/GridController.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.conveyal.r5.analyst.Grid;
-import com.conveyal.r5.common.JsonUtilities;
 import com.conveyal.taui.AnalystConfig;
 import com.conveyal.taui.grids.GridExtractor;
 import com.conveyal.taui.grids.SeamlessCensusGridExtractor;
@@ -27,17 +26,11 @@ import spark.Response;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
-import static spark.Spark.get;
-import static spark.Spark.halt;
-import static spark.Spark.post;
+import static com.conveyal.taui.util.SparkUtil.haltWithJson;
+import static spark.Spark.*;
 
 /**
  * Controller that handles fetching grids.
@@ -156,7 +149,7 @@ public class GridController {
 
         if (file.size() != 1) {
             LOG.warn("CSV upload only supports one file at a time");
-            halt(400);
+            haltWithJson(400, "CSV upload only supports one file at a time.");
         }
 
         // create a temp file because we have to loop over it twice
@@ -198,7 +191,7 @@ public class GridController {
         if (!filesByName.containsKey(baseName + ".shp") ||
                     !filesByName.containsKey(baseName + ".prj") ||
                     !filesByName.containsKey(baseName + ".dbf")) {
-            halt(400, "Shapefile upload must contain .shp, .prj, and .dbf");
+            haltWithJson(400, "Shapefile upload must contain .shp, .prj, and .dbf");
         }
 
         File tempDir = Files.createTempDir();

--- a/src/main/java/com/conveyal/taui/controllers/ModificationController.java
+++ b/src/main/java/com/conveyal/taui/controllers/ModificationController.java
@@ -13,7 +13,11 @@ import spark.Response;
 import java.io.IOException;
 
 import static com.conveyal.taui.util.SparkUtil.haltWithJson;
-import static spark.Spark.*;
+import static spark.Spark.delete;
+import static spark.Spark.get;
+import static spark.Spark.options;
+import static spark.Spark.post;
+import static spark.Spark.put;
 
 /**
  * Controller for persisting modifications.

--- a/src/main/java/com/conveyal/taui/controllers/ModificationController.java
+++ b/src/main/java/com/conveyal/taui/controllers/ModificationController.java
@@ -5,21 +5,15 @@ import com.conveyal.taui.models.Modification;
 import com.conveyal.taui.models.Scenario;
 import com.conveyal.taui.persistence.Persistence;
 import com.conveyal.taui.util.JsonUtil;
-import com.fasterxml.jackson.core.JsonParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
 import java.io.IOException;
-import java.util.Collection;
 
-import static spark.Spark.delete;
-import static spark.Spark.halt;
-import static spark.Spark.get;
-import static spark.Spark.post;
-import static spark.Spark.put;
-import static spark.Spark.options;
+import static com.conveyal.taui.util.SparkUtil.haltWithJson;
+import static spark.Spark.*;
 
 /**
  * Controller for persisting modifications.
@@ -38,7 +32,7 @@ public class ModificationController {
             mod = JsonUtilities.objectMapper.readValue(req.body(), Modification.class);
         } catch (IOException e) {
             LOG.info("Error parsing modification JSON from client", e);
-            halt(400, "Bad modification");
+            haltWithJson(400, "Error parsing modification JSON from client");
         }
 
         Persistence.modifications.put(mod.id, mod);
@@ -48,7 +42,9 @@ public class ModificationController {
 
     public static Modification deleteModification (Request req, Response res) {
         Modification m = Persistence.modifications.get(req.params("id"));
-        if (m == null) halt(404);
+        if (m == null) {
+            haltWithJson(404, "Unable to delete modification. Modification does not exist.");
+        }
 
         Scenario s = Persistence.scenarios.get(m.scenario);
 

--- a/src/main/java/com/conveyal/taui/controllers/ProjectController.java
+++ b/src/main/java/com/conveyal/taui/controllers/ProjectController.java
@@ -21,7 +21,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.conveyal.taui.util.SparkUtil.haltWithJson;
-import static spark.Spark.*;
+import static spark.Spark.delete;
+import static spark.Spark.get;
+import static spark.Spark.post;
+import static spark.Spark.put;
 
 /**
  * Created by matthewc on 7/12/16.

--- a/src/main/java/com/conveyal/taui/controllers/ProjectController.java
+++ b/src/main/java/com/conveyal/taui/controllers/ProjectController.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.conveyal.taui.util.SparkUtil.haltWithJson;
 import static spark.Spark.*;
 
 /**
@@ -33,7 +34,9 @@ public class ProjectController {
     public static Project getProject (Request req, Response res) {
         Project project = Persistence.projects.get(req.params("id"));
 
-        if (project == null) halt(404);
+        if (project == null) {
+            haltWithJson(404, "Project does not exist for ID: " + req.params("id") + ".");
+        }
 
         return project;
     }
@@ -56,7 +59,7 @@ public class ProjectController {
             is.close();
         } catch (Exception e) {
             LOG.error("Could not deserialize project from client", e);
-            halt(400, "Bad project");
+            haltWithJson(400, "Could not deserialize project from client");
         }
 
         project.group = req.attribute("group");
@@ -64,7 +67,7 @@ public class ProjectController {
         Project existing = Persistence.projects.get(project.id);
 
         if (existing != null && !existing.group.equals(project.group)) {
-            halt(401, "Attempt to overwrite existing project belonging to other user");
+            haltWithJson(401, "Attempt to overwrite existing project belonging to other user");
         }
 
         Persistence.projects.put(project.id, project);
@@ -116,7 +119,7 @@ public class ProjectController {
     public static Project deleteProject (Request req, Response res) {
         String id = req.params("id");
         Project project = Persistence.projects.get(id);
-        if (project == null) halt(404);
+        if (project == null) haltWithJson(404, "Project ID: " + id + " does not exist on the server.");
 
         return Persistence.projects.remove(id);
     }

--- a/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
@@ -36,7 +36,9 @@ import java.util.zip.GZIPOutputStream;
 
 import static com.conveyal.taui.util.SparkUtil.haltWithJson;
 import static java.lang.Boolean.parseBoolean;
-import static spark.Spark.*;
+import static spark.Spark.delete;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 /**
  * Created by matthewc on 10/21/16.

--- a/src/main/java/com/conveyal/taui/controllers/ScenarioController.java
+++ b/src/main/java/com/conveyal/taui/controllers/ScenarioController.java
@@ -12,16 +12,25 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+import static com.conveyal.taui.util.SparkUtil.haltWithJson;
 import static spark.Spark.*;
 
 /**
  * Controller for scenarios.
  */
 public class ScenarioController {
+    private static Scenario getAndHaltIfMissing (String id) {
+        Scenario scenario = Persistence.scenarios.get(id);
+        if (scenario == null) {
+            haltWithJson(404, "Scenario ID " + id + " does not exist.");
+        }
+        return scenario;
+    }
+
     public static Scenario getScenario (Request req, Response res) {
         String id = req.params("id");
         String group = (String) req.attribute("group");
-        Scenario scenario = Persistence.scenarios.get(id);
+        Scenario scenario = getAndHaltIfMissing(id);
 
         return scenario;
     }
@@ -38,13 +47,13 @@ public class ScenarioController {
         try {
             scenario = JsonUtilities.objectMapper.readValue(req.body(), Scenario.class);
         } catch (IOException e) {
-            halt(400, "Bad scenario");
+            haltWithJson(400, "Unable to parse Scenario JSON sent from the client.");
         }
 
         Scenario existing = Persistence.scenarios.get(scenario.id);
 
         if (existing != null && !scenario.projectId.equals(existing.projectId)) {
-            halt(403);
+            haltWithJson(403, "Cannot change a Scenario's project.");
         }
 
         Persistence.scenarios.put(scenario.id, scenario);
@@ -53,20 +62,11 @@ public class ScenarioController {
     }
 
     public static Collection<Modification> modifications (Request req, Response res) {
-        String id = req.params("id");
-        Scenario scenario = Persistence.scenarios.get(id);
-
-        if (scenario == null) halt(404);
-
-        return Persistence.modifications.getByProperty("scenario", id);
+        return Persistence.modifications.getByProperty("scenario", req.params("id"));
     }
 
     public static Scenario deleteScenario (Request req, Response res) {
-        String id = req.params("id");
-        Scenario scenario = Persistence.scenarios.get(id);
-        if (scenario == null) halt(404);
-
-        return Persistence.scenarios.remove(id);
+        return Persistence.scenarios.remove(req.params("id"));
     }
 
     public static void register () {

--- a/src/main/java/com/conveyal/taui/controllers/ScenarioController.java
+++ b/src/main/java/com/conveyal/taui/controllers/ScenarioController.java
@@ -13,7 +13,11 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import static com.conveyal.taui.util.SparkUtil.haltWithJson;
-import static spark.Spark.*;
+import static spark.Spark.delete;
+import static spark.Spark.get;
+import static spark.Spark.options;
+import static spark.Spark.post;
+import static spark.Spark.put;
 
 /**
  * Controller for scenarios.

--- a/src/main/java/com/conveyal/taui/util/SparkUtil.java
+++ b/src/main/java/com/conveyal/taui/util/SparkUtil.java
@@ -1,0 +1,12 @@
+package com.conveyal.taui.util;
+
+import static spark.Spark.halt;
+
+/**
+ * Created by trevorgerhardt on 9/12/17.
+ */
+public class SparkUtil {
+    public static void haltWithJson(int code, String message) {
+        halt(code, "{\"message\":\"" + message + "\"}");
+    }
+}


### PR DESCRIPTION
There were a ton of "halt"'s sprinkled throughout the code base without a corresponding message. Along with that, our default response type is application/json which would confuse the client if it received only text. This commit adds a helper function to format halt messages into a common JSON format and ensures that each halt passes along a corresponding message.