### PR TITLE
Update gtfs-lib to v1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>1.3.1</version>
+            <version>1.4.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/conveyal/taui/controllers/SinglePointAnalysisController.java
+++ b/src/main/java/com/conveyal/taui/controllers/SinglePointAnalysisController.java
@@ -1,9 +1,7 @@
 package com.conveyal.taui.controllers;
 
-import com.conveyal.r5.analyst.error.TaskError;
-import com.conveyal.r5.common.JsonUtilities;
-import com.conveyal.taui.util.HttpUtil;
 import com.conveyal.taui.AnalystConfig;
+import com.conveyal.taui.util.HttpUtil;
 import com.google.common.io.ByteStreams;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
@@ -21,10 +19,11 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
 
-import static spark.Spark.*;
+import static com.conveyal.taui.util.SparkUtil.haltWithJson;
+import static spark.Spark.delete;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 /**
  * Handles talking to the broker.
@@ -70,24 +69,21 @@ public class SinglePointAnalysisController {
                 is.close();
                 EntityUtils.consume(brokerRes.getEntity());
             } catch (Exception e) {
-                reportException(res, e);
+                reportException(e);
             }
             return baos.toByteArray();
         } catch (Exception e) {
-            reportException(res, e);
+            reportException(e);
         } finally {
             if (brokerRes != null) brokerRes.close();
         }
         return null;
     }
 
-    public static void reportException (Response response, Exception exception) {
+    private static void reportException (Exception exception) {
         LOG.error("Uncaught exception: ", exception.toString());
         exception.printStackTrace();
-        response.status(500);
-        response.type("application/json");
-        List<TaskError> taskErrors = Arrays.asList(new TaskError(exception));
-        response.body(new String(JsonUtilities.objectToJsonBytes(taskErrors)));
+        haltWithJson(500, exception);
     }
 
     public static void register () {

--- a/src/main/java/com/conveyal/taui/models/Bundle.java
+++ b/src/main/java/com/conveyal/taui/models/Bundle.java
@@ -90,7 +90,7 @@ public class Bundle extends Model implements Cloneable {
 
         public FeedSummary(GTFSFeed feed, Bundle bundle) {
             feedId = feed.feedId;
-            bundleScopedFeedId = String.format("%s_%s", feed.feedId, bundle.id);
+            bundleScopedFeedId = String.format("%s-%s", feed.feedId, bundle.id);
             name = feed.agency.size() > 0 ? feed.agency.values().iterator().next().agency_name : feed.feedId;
             checksum = feed.checksum;
         }

--- a/src/main/java/com/conveyal/taui/util/SparkUtil.java
+++ b/src/main/java/com/conveyal/taui/util/SparkUtil.java
@@ -9,4 +9,9 @@ public class SparkUtil {
     public static void haltWithJson(int code, String message) {
         halt(code, "{\"message\":\"" + message + "\"}");
     }
+
+    public static void haltWithJson(int code, Exception e) {
+        e.printStackTrace();
+        halt(code, String.format("{\"message\":\"%s\",\"stack\":\"%s\"}", e.getMessage(), e.getStackTrace().toString()));
+    }
 }


### PR DESCRIPTION
This commit updates gtfs-lib to v1.4.0 to bring it to parity with the version of gtfs-api that is included. It also updates the style of creating `bundleScopedFeedId`s (how we reference the stored zip and db files) from using underscores to hyphens. This will require a database migration and a
filename replacement of all stored feeds.

Also improves bubbling up the exceptions to the user for when this fails in the future.

addresses #56