### PR TITLE
Fix bundle / feed name editing

### DIFF
--- a/src/main/java/com/conveyal/taui/models/Bundle.java
+++ b/src/main/java/com/conveyal/taui/models/Bundle.java
@@ -7,7 +7,6 @@ import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.r5.analyst.cluster.BundleManifest;
 import com.conveyal.taui.AnalysisServerConfig;
 import com.conveyal.taui.util.JsonUtil;
-import com.fasterxml.jackson.annotation.JsonView;
 
 import java.io.File;
 import java.io.IOException;
@@ -80,8 +79,6 @@ public class Bundle extends Model implements Cloneable {
         public String fileName;
 
         /** The feed ID scoped with the bundle ID, for use as a unique identifier on S3 and in the GTFS API */
-        // don't expose to client to avoid confusion
-        @JsonView(JsonViews.Db.class)
         public String bundleScopedFeedId;
 
         public LocalDate serviceStart;


### PR DESCRIPTION
We were hiding the bundleScopedFeedId from the client which caused a "save" over the FeedSummary with client data to leave that value empty. We use that value enough that we should not hide it from the client.

refs #16