### PR TITLE
Update GTFS API to v1.1.0 to include FeedSource feed id changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-api</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
From this commit https://github.com/conveyal/gtfs-api/commit/b30df9e3b36549b89ddca717b796d106f9713bb0