### PR TITLE
Rename "Grids" and "Indicators" to "Opportunity Datasets"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>r5</artifactId>
-            <version>3.0.0</version>
+            <version>3.3.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>r5</artifactId>
-            <version>3.3.0</version>
+            <version>3.2.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/conveyal/taui/AnalysisServer.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServer.java
@@ -7,7 +7,7 @@ import com.conveyal.taui.analysis.LocalCluster;
 import com.conveyal.taui.controllers.AggregationAreaController;
 import com.conveyal.taui.controllers.BundleController;
 import com.conveyal.taui.controllers.GraphQLController;
-import com.conveyal.taui.controllers.GridController;
+import com.conveyal.taui.controllers.OpportunityDatasetsController;
 import com.conveyal.taui.controllers.ModificationController;
 import com.conveyal.taui.controllers.ProjectController;
 import com.conveyal.taui.controllers.RegionalAnalysisController;
@@ -132,7 +132,7 @@ public class AnalysisServer {
         GraphQLController.register();
         BundleController.register();
         SinglePointAnalysisController.register();
-        GridController.register();
+        OpportunityDatasetsController.register();
         RegionalAnalysisController.register();
         AggregationAreaController.register();
 

--- a/src/main/java/com/conveyal/taui/controllers/ProjectController.java
+++ b/src/main/java/com/conveyal/taui/controllers/ProjectController.java
@@ -91,7 +91,7 @@ public class ProjectController {
                     if (existing == null || !existing.bounds.equals(finalProject.bounds, 1e-6)) {
                         // fetch census data
                         finalProject.fetchCensus();
-                        // save indicators
+                        // save opportunityDatasets
                         Persistence.projects.put(finalProject.id, finalProject);
                     }
                 } catch (Exception e) {
@@ -108,7 +108,7 @@ public class ProjectController {
                     finalProject.fetchOsm();
                     finalProject.fetchCensus();
                     Project.loadStatusForProject.remove(finalProject.id);
-                    // save indicators
+                    // save opportunityDatasets
                     Persistence.projects.put(finalProject.id, finalProject);
                 } catch (IOException e) {
                     LOG.error("Exception fetching OSM", e);

--- a/src/main/java/com/conveyal/taui/grids/GridExtractor.java
+++ b/src/main/java/com/conveyal/taui/grids/GridExtractor.java
@@ -23,9 +23,9 @@ public abstract class GridExtractor {
     // A pool of threads that upload newly created grids to S3. The pool is shared between all GridFetchers.
     // The default policy when the pool's work queue is full is to abort with an exception.
     // We shouldn't use the caller-runs policy because that will cause deadlocks.
-    private static ThreadPoolExecutor s3Upload = new ThreadPoolExecutor(4, 8, 90, TimeUnit.SECONDS, new ArrayBlockingQueue<>(1024));
+    public static ThreadPoolExecutor s3Upload = new ThreadPoolExecutor(4, 8, 90, TimeUnit.SECONDS, new ArrayBlockingQueue<>(1024));
 
-    private static AmazonS3 s3 = new AmazonS3Client();
+    public static AmazonS3 s3 = new AmazonS3Client();
 
     /** Human readable name for this source of grids. */
     public String name;

--- a/src/main/java/com/conveyal/taui/grids/SeamlessCensusGridExtractor.java
+++ b/src/main/java/com/conveyal/taui/grids/SeamlessCensusGridExtractor.java
@@ -40,9 +40,9 @@ public class SeamlessCensusGridExtractor extends GridExtractor {
      *
      * The status callback will be called periodically to return the status of the fetch to the API.
      */
-    public List<Project.Indicator> extractData (String targetBucket, String s3prefix,
-                                                double north, double east, double south, double west,
-                                                Consumer<Project.LoadStatus> statusCallback) {
+    public List<Project.OpportunityDataset> extractData (String targetBucket, String s3prefix,
+                                                         double north, double east, double south, double west,
+                                                         Consumer<Project.LoadStatus> statusCallback) {
         long startTime = System.currentTimeMillis();
 
         statusCallback.accept(Project.LoadStatus.DOWNLOADING_CENSUS);
@@ -106,7 +106,7 @@ public class SeamlessCensusGridExtractor extends GridExtractor {
         statusCallback.accept(Project.LoadStatus.STORING_CENSUS);
 
         // Write all the resulting grids out to gzipped objects on S3, and make a list of model objects for them.
-        List<Project.Indicator> indicators = new ArrayList<>();
+        List<Project.OpportunityDataset> opportunityDatasets = new ArrayList<>();
         gridForAttribute.forEach((attribute, grid) -> {
             String cleanedAttributeName = attribute
                     .replaceAll(" ", "_")
@@ -129,17 +129,17 @@ public class SeamlessCensusGridExtractor extends GridExtractor {
             }
 
             // Create an object representing this new destination density grid in the Analysis backend internal model.
-            Project.Indicator indicator = new Project.Indicator();
-            indicator.dataSource = this.name;
-            indicator.name = attribute;
-            indicator.key = cleanedAttributeName;
-            indicators.add(indicator);
+            Project.OpportunityDataset opportunityDataset = new Project.OpportunityDataset();
+            opportunityDataset.dataSource = this.name;
+            opportunityDataset.name = attribute;
+            opportunityDataset.key = cleanedAttributeName;
+            opportunityDatasets.add(opportunityDataset);
         });
 
         long endTime = System.currentTimeMillis();
         LOG.info("Extracting Census data took {} seconds", (endTime - startTime) / 1000);
 
         // Return an internal model object for each census grid that was created.
-        return indicators;
+        return opportunityDatasets;
     }
 }

--- a/src/main/java/com/conveyal/taui/models/Bookmark.java
+++ b/src/main/java/com/conveyal/taui/models/Bookmark.java
@@ -2,8 +2,6 @@ package com.conveyal.taui.models;
 
 import com.conveyal.r5.profile.ProfileRequest;
 
-import java.time.LocalDate;
-
 /**
  * A bookmark represents "frozen" settings for single point results.
  */
@@ -16,7 +14,7 @@ public class Bookmark extends Model {
     public int isochroneCutoff;
 
     /** The destination grid */
-    public String destinationGrid;
+    public String opportunityDataset;
 
     /** The project ID of this bookmark */
     public String projectId;

--- a/src/main/java/com/conveyal/taui/models/Project.java
+++ b/src/main/java/com/conveyal/taui/models/Project.java
@@ -99,7 +99,7 @@ public class Project extends Model implements Cloneable {
         return Persistence.aggregationAreas.getByProperty("projectId", id);
     }
 
-    public List<Indicator> indicators = new ArrayList<>();
+    public List<OpportunityDataset> opportunityDatasets = new ArrayList<>();
 
     public synchronized void fetchOsm () throws IOException {
         loadStatusForProject.put(id, LoadStatus.DOWNLOADING_OSM);
@@ -136,7 +136,7 @@ public class Project extends Model implements Cloneable {
     }
 
     public synchronized void fetchCensus () {
-        this.indicators.addAll(gridFetcher.extractData(AnalysisServerConfig.gridBucket, this.id,
+        this.opportunityDatasets.addAll(gridFetcher.extractData(AnalysisServerConfig.gridBucket, this.id,
                 bounds.north,
                 bounds.east,
                 bounds.south,
@@ -170,12 +170,12 @@ public class Project extends Model implements Cloneable {
         }
     }
 
-    /** Represents an indicator */
-    public static class Indicator {
+    /** Represents an Opportunity Dataset */
+    public static class OpportunityDataset {
         /** The human-readable name of the data source from which this came */
         public String dataSource;
 
-        /** The human readable name of the indicator */
+        /** The human readable name of the dataset */
         public String name;
 
         /** The key on S3 */


### PR DESCRIPTION
Unless they directly relate to the grid files themselves. Also, add an endpoint for removing the dataset from a project.

# TODOS
- [x] Merge this front end change: https://github.com/conveyal/analysis-ui/pull/528
- [x] Merge this r5 PR: https://github.com/conveyal/r5/pull/357, release and then update the pom.xml
- [ ] DB Migration (see below)

### DB Migration
Projects
```js
$ db.projects.updateMany({}, {$rename: {"indicators": "opportunityDatasets"}})
```
Bookmarks
```js
$ db.bookmarks.updateMany({}, {$rename: {"destinationGrid": "opportunityDataset"}})
```