### PR TITLE
Adapt to new broker, reducing memory consumption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>r5</artifactId>
-            <version>4.0.0-20171109.183530-3</version>
+            <version>4.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This change depends on the new broker API implemented in PR conveyal/r5#372 .
It just sends a single tempate task which the broker expands into a full regional set of tasks.

