### PR TITLE
Replace generic exceptions with AnalysisServerExceptions

### DIFF
--- a/src/main/java/com/conveyal/taui/analysis/RegionalAnalysisManager.java
+++ b/src/main/java/com/conveyal/taui/analysis/RegionalAnalysisManager.java
@@ -12,6 +12,7 @@ import com.conveyal.r5.analyst.cluster.GridResultQueueConsumer;
 import com.conveyal.r5.analyst.cluster.RegionalTask;
 import com.conveyal.r5.analyst.scenario.Scenario;
 import com.conveyal.taui.AnalysisServerConfig;
+import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.models.RegionalAnalysis;
 import com.conveyal.taui.persistence.TiledAccessGrid;
 import com.conveyal.taui.util.HttpUtil;
@@ -116,7 +117,7 @@ public class RegionalAnalysisManager {
                 }
             } catch (IOException e) {
                 LOG.error("error enqueueing requests", e);
-                throw new RuntimeException("error enqueueing requests", e);
+                throw AnalysisServerException.Unknown(e);
             }
 
             consumer.registerJob(templateTask,

--- a/src/main/java/com/conveyal/taui/controllers/OpportunityDatasetsController.java
+++ b/src/main/java/com/conveyal/taui/controllers/OpportunityDatasetsController.java
@@ -283,7 +283,7 @@ public class OpportunityDatasetsController {
         if (!s3.doesObjectExist(BUCKET, String.format("%s.%s", gridPath, format))) {
             // if this grid is not on S3 in the requested format, try to get the .grid format
             if (!s3.doesObjectExist(BUCKET, String.format("%s.grid", gridPath))) {
-                throw new IllegalArgumentException("This grid does not exist.");
+                throw AnalysisServerException.NotFound("This grid does not exist.");
             } else {
                 // get the grid and convert it to the requested format
                 S3Object s3Grid = s3.getObject(BUCKET, String.format("%s.grid", gridPath));
@@ -327,7 +327,7 @@ public class OpportunityDatasetsController {
                 status.status = Status.ERROR;
                 status.message = e.getMessage();
                 status.completed();
-                throw new RuntimeException(e);
+                throw AnalysisServerException.Unknown(e);
             }
 
             Region.OpportunityDataset opportunityDataset = new Region.OpportunityDataset();

--- a/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
@@ -7,6 +7,7 @@ import com.conveyal.r5.analyst.Grid;
 import com.conveyal.r5.analyst.SelectingGridReducer;
 import com.conveyal.r5.analyst.cluster.RegionalTask;
 import com.conveyal.taui.AnalysisServerConfig;
+import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.analysis.RegionalAnalysisManager;
 import com.conveyal.taui.grids.GridExporter;
 import com.conveyal.taui.models.AnalysisRequest;
@@ -95,7 +96,7 @@ public class RegionalAnalysisController {
                 // Andrew Owen style average instantaneous accessibility
                 // The samples stored in the access grid are samples of instantaneous accessibility at different minutes
                 // and Monte Carlo draws, average them together
-                throw new IllegalArgumentException("Old-style instantaneous-accessibility regional analyses are no longer supported");
+                throw AnalysisServerException.BadRequest("Old-style instantaneous-accessibility regional analyses are no longer supported");
             } else {
                 // This is accessibility given x percentile travel time, the first sample is the point estimate
                 // computed using all monte carlo draws, and subsequent samples are bootstrap replications. Return the

--- a/src/main/java/com/conveyal/taui/models/Bundle.java
+++ b/src/main/java/com/conveyal/taui/models/Bundle.java
@@ -6,6 +6,7 @@ import com.conveyal.gtfs.GTFSCache;
 import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.r5.analyst.cluster.BundleManifest;
 import com.conveyal.taui.AnalysisServerConfig;
+import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.util.JsonUtil;
 
 import java.io.File;
@@ -62,7 +63,7 @@ public class Bundle extends Model implements Cloneable {
         try {
             return (Bundle) super.clone();
         } catch (CloneNotSupportedException e) {
-            throw new RuntimeException(e);
+            throw AnalysisServerException.Unknown(e);
         }
     }
 
@@ -93,7 +94,7 @@ public class Bundle extends Model implements Cloneable {
             try {
                 return (FeedSummary) super.clone();
             } catch (CloneNotSupportedException e) {
-                throw new RuntimeException(e);
+                throw AnalysisServerException.Unknown(e);
             }
         }
     }

--- a/src/main/java/com/conveyal/taui/models/Project.java
+++ b/src/main/java/com/conveyal/taui/models/Project.java
@@ -1,5 +1,7 @@
 package com.conveyal.taui.models;
 
+import com.conveyal.taui.AnalysisServerException;
+
 /**
  * Represents a TAUI project
  */
@@ -15,7 +17,7 @@ public class Project extends Model implements Cloneable {
         try {
             return (Project) super.clone();
         } catch (CloneNotSupportedException e) {
-            throw new RuntimeException(e);
+            throw AnalysisServerException.Unknown(e);
         }
     }
 }

--- a/src/main/java/com/conveyal/taui/models/Region.java
+++ b/src/main/java/com/conveyal/taui/models/Region.java
@@ -1,5 +1,6 @@
 package com.conveyal.taui.models;
 
+import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.persistence.Persistence;
 import com.fasterxml.jackson.annotation.JsonView;
 
@@ -64,7 +65,7 @@ public class Region extends Model implements Cloneable {
             return (Region) super.clone();
         } catch (CloneNotSupportedException e) {
             // can't happen.
-            throw new RuntimeException(e);
+            throw AnalysisServerException.Unknown(e);
         }
     }
 

--- a/src/main/java/com/conveyal/taui/models/RegionalAnalysis.java
+++ b/src/main/java/com/conveyal/taui/models/RegionalAnalysis.java
@@ -1,6 +1,7 @@
 package com.conveyal.taui.models;
 
 import com.conveyal.r5.analyst.cluster.RegionalTask;
+import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.analysis.RegionalAnalysisManager;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.vividsolutions.jts.geom.Envelope;
@@ -81,7 +82,7 @@ public class RegionalAnalysis extends Model implements Cloneable {
         try {
             return (RegionalAnalysis) super.clone();
         } catch (CloneNotSupportedException e) {
-            throw new RuntimeException(e);
+            throw AnalysisServerException.Unknown(e);
         }
     }
 }

--- a/src/main/java/com/conveyal/taui/persistence/MongoMap.java
+++ b/src/main/java/com/conveyal/taui/persistence/MongoMap.java
@@ -49,7 +49,7 @@ public class MongoMap<V extends Model> implements Map<String, V> {
     }
 
     public boolean containsValue(Object value) {
-        throw new UnsupportedOperationException();
+        throw AnalysisServerException.Unknown("Unsupported operation");
     }
 
     public V findByIdFromRequestIfPermitted(Request request) {
@@ -135,7 +135,7 @@ public class MongoMap<V extends Model> implements Map<String, V> {
     }
 
     public V put(String key, V value) {
-        if (key != value._id) throw new IllegalArgumentException("ID does not match");
+        if (key != value._id) throw AnalysisServerException.BadRequest("ID does not match");
         return put(value, null);
     }
 
@@ -203,7 +203,7 @@ public class MongoMap<V extends Model> implements Map<String, V> {
         WriteResult<V, String> result = wrappedCollection.removeById((String) key);
         LOG.info(result.toString());
         if (result.getN() == 0) {
-            throw new RuntimeException(String.format("The data for _id %s does not exist", key));
+            throw AnalysisServerException.NotFound(String.format("The data for _id %s does not exist", key));
         }
 
         return null;

--- a/src/main/java/com/conveyal/taui/persistence/OSMPersistence.java
+++ b/src/main/java/com/conveyal/taui/persistence/OSMPersistence.java
@@ -3,6 +3,7 @@ package com.conveyal.taui.persistence;
 import com.conveyal.osmlib.OSM;
 import com.conveyal.osmlib.OSMCache;
 import com.conveyal.taui.AnalysisServerConfig;
+import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.models.Bounds;
 import com.conveyal.taui.util.HttpUtil;
 import com.google.common.io.ByteStreams;
@@ -38,7 +39,7 @@ public class OSMPersistence {
             res = HttpUtil.httpClient.execute(get);
 
             if (res.getStatusLine().getStatusCode() != 200) {
-                throw new Exception("Could not retrieve OSM. " + res.getStatusLine());
+                throw AnalysisServerException.Unknown("Could not retrieve OSM. " + res.getStatusLine());
             }
 
             InputStream is = res.getEntity().getContent();


### PR DESCRIPTION
I created `AnalysisServerException`s as a way for Spark to be able to deliver more precise error messages, stackTraces and status codes to the client. This PR replaces the rest of the usages of the generic Java Exceptions.