### PR TITLE
chore(r5): update r5 dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>r5</artifactId>
-            <version>4.0.0-20171109.183530-3</version>
+            <version>4.0.0-20171222.235031-4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This includes some optimizations that were already deployed to production (but in a SNAPSHOT dependency,  which was then locked to a specific version)