### PR TITLE
Add parameter to produce static sites from regional analyses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>r5</artifactId>
-            <version>3.4.1</version>
+            <version>4.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
@@ -1,5 +1,6 @@
 package com.conveyal.taui.controllers;
 
+import com.amazonaws.services.devicefarm.model.ExecutionResult;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.conveyal.r5.analyst.BootstrapPercentileMethodHypothesisTestGridReducer;
@@ -167,7 +168,18 @@ public class RegionalAnalysisController {
         task.x = 0;
         task.y = 0;
 
-        // TODO remove duplicate data that is already in the task
+        // If the UI has requested creation of a "static site", set all the necessary switches on the requests
+        // that will go to the worker: break travel time down into waiting, riding, and walking, record paths to
+        // destinations, and save results on S3.
+        if (analysisRequest.makeStaticSite) {
+            task.makeStaticSite = true;
+            task.travelTimeBreakdown = true;
+            task.returnPaths = true;
+        }
+
+        // TODO remove duplicate fields from RegionalAnalysis that are already in the nested task.
+        // The RegionalAnalysis object contains a reference to the template task itself.
+        // In fact, there are three separate classes all containing almost the same info: AnalysisRequest, RegionalTask, RegionalAnalysis.
         RegionalAnalysis regionalAnalysis = new RegionalAnalysis();
 
         regionalAnalysis.height = task.height;

--- a/src/main/java/com/conveyal/taui/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/taui/models/AnalysisRequest.java
@@ -18,6 +18,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 
+/**
+ * This is the request sent from the UI. It is actually distinct from the requests sent to the R5 workers, though it
+ * has many of the same fields.
+ */
 public class AnalysisRequest {
     private static int ZOOM = 9;
 
@@ -58,6 +62,8 @@ public class AnalysisRequest {
     public String name;
     public String opportunityDatasetKey;
     public Integer travelTimePercentile;
+    // Save all results in a regional analysis to S3 for display in a "static site".
+    public boolean makeStaticSite = false;
 
     /**
      * Get all of the modifications for a project id that are in the Variant and map them to their corresponding r5 mod
@@ -75,6 +81,9 @@ public class AnalysisRequest {
      * Finds the modifications for the specified project and variant, maps them to their corresponding R5 modification
      * types, creates a checksum from those modifications, and adds them to the AnalysisTask along with the rest of the
      * request.
+     *
+     * This method takes a task as a parameter, modifies that task, and also returns that same task.
+     * This is because we have two subtypes of AnalysisTask and need to be able to create both.
      */
     public AnalysisTask populateTask (AnalysisTask task, Project project) {
         List<Modification> modifications = new ArrayList<>();
@@ -93,6 +102,8 @@ public class AnalysisRequest {
 
         task.scenario = new Scenario();
         // TODO figure out why we use both
+        // (AB: what does the above comment mean? both what?)
+        // FIXME Job IDs need to be unique. Why are we setting this to the project and variant? This only works because the job ID is overwritten when the job is enqueued.
         task.jobId = String.format("%s-%s-%s", projectId, variantIndex, crcValue);
         task.scenario.id = task.scenarioId = task.jobId;
         task.scenario.modifications = modifications;


### PR DESCRIPTION
This has been tested with makeStaticSite = false (produces a regional accessibility map) and with makeStaticSite = true (saves a bunch of travel time and path files to S3).
Requires corresponding changes in R5 branch enable-static-sites