### PR TITLE
Update gtfs-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-api</artifactId>
-            <version>1.1.0</version>
+            <version>3.1.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Short-term fix that attempts to address a memory problem by using this branch of gtfs-api: https://github.com/conveyal/gtfs-api/commits/remove-indexing

I'm proposing a merge directly into master, since recent changes in dev need additional work before we deploy.