### PR TITLE
Update bundle status on failure

### DIFF
--- a/analysis.properties
+++ b/analysis.properties
@@ -1,14 +1,14 @@
 # This file contains the configuration options for Conveyal Analysis
 
 # Auth0 authentication configuration. The values will be ignored when configuration option offline=true.
-auth0-client-id=X
-auth0-secret=Y
+auth0-client-id=E8i1DpX5QLQmOReZXOPpbIuFIawykOTh
+auth0-secret=i2dzx7WMDvdBzrarsgxtsDJ4iveP5kFXlH0-OfFXZbyp3P02XN4z3_0MP_AgVw5U
 
 # The host and port of the remote Mongo server (if any). Comment out for local Mongo instance.
 # database-uri=mongodb://127.0.0.1:27017
 
 # The name of the database in the Mongo instance.
-database-name=scenario-editor
+database-name=analysis
 
 # The URL where the frontend is hosted.
 # In production this should point to a cached CDN for speed. e.g. https://d1uqjuy3laovxb.cloudfront.net
@@ -48,6 +48,9 @@ local-cache=cache
 # The broker is running on the same instance as the main backend, which is visible on the internet.
 # Internet since it also runs the frontend server)
 server-address=10.0.0.123
+
+# Maximum Java threads to execute concurrently.
+max-threads=1
 
 # Max number of instances to start.
 # If there are more than this number running more instances will not be started.

--- a/src/main/java/com/conveyal/taui/AnalysisServer.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServer.java
@@ -3,6 +3,7 @@ package com.conveyal.taui;
 import com.auth0.jwt.JWTVerifier;
 import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.gtfs.api.util.FeedSourceCache;
+import com.conveyal.r5.util.ExceptionUtils;
 import com.conveyal.taui.analysis.broker.Broker;
 import com.conveyal.taui.analysis.LocalCluster;
 import com.conveyal.taui.controllers.AggregationAreaController;
@@ -18,7 +19,6 @@ import com.conveyal.taui.persistence.OSMPersistence;
 import com.conveyal.taui.persistence.Persistence;
 import com.google.common.io.CharStreams;
 import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.joda.time.DateTime;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
@@ -188,7 +188,7 @@ public class AnalysisServer {
         try {
             jwt = verifier.verify(authComponents[1]);
         } catch (Exception e) {
-            throw AnalysisServerException.forbidden("Login failed to verify with our authorization provider. " + e.getMessage());
+            throw AnalysisServerException.forbidden("Login failed to verify with our authorization provider. " + ExceptionUtils.asString(e));
         }
 
         if (!jwt.containsKey("analyst")) {
@@ -199,7 +199,7 @@ public class AnalysisServer {
         try {
             group = (String) ((Map<String, Object>) jwt.get("analyst")).get("group");
         } catch (Exception e) {
-            throw AnalysisServerException.forbidden("Access denied. User is not associated with any group. " + e.getMessage());
+            throw AnalysisServerException.forbidden("Access denied. User is not associated with any group. " + ExceptionUtils.asString(e));
         }
 
         if (group == null) {
@@ -212,7 +212,7 @@ public class AnalysisServer {
     }
 
     public static void respondToException(Exception e, Request request, Response response, String type, String message, int code) {
-        String stack = ExceptionUtils.getStackTrace(e);
+        String stack = ExceptionUtils.asString(e);
 
         LOG.error("{} {} -> {} {} by {} of {}", type, message, request.requestMethod(), request.pathInfo(), request.attribute("email"), request.attribute("accessGroup"));
         LOG.error(stack);

--- a/src/main/java/com/conveyal/taui/AnalysisServerConfig.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServerConfig.java
@@ -50,6 +50,7 @@ public abstract class AnalysisServerConfig {
     public static final String resultsBucket = getProperty("results-bucket", true);
     public static final String awsRegion = getProperty("aws-region", true);
     public static final String workerLogGroup = getProperty("worker-log-group", true);
+    public static final int maxThreads = Integer.parseInt(getProperty("max-threads", true));
     public static final int maxWorkers = Integer.parseInt(getProperty("max-workers", true));
 
     // AWS specific stuff. This should be moved to another config object when we make this portable to other environments.

--- a/src/main/java/com/conveyal/taui/AnalysisServerException.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServerException.java
@@ -1,13 +1,10 @@
 package com.conveyal.taui;
 
+import com.conveyal.r5.util.ExceptionUtils;
 import graphql.GraphQLError;
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import spark.Response;
 
-import java.io.IOException;
 import java.util.List;
 
 public class AnalysisServerException extends RuntimeException {
@@ -66,7 +63,7 @@ public class AnalysisServerException extends RuntimeException {
     }
 
     public static AnalysisServerException unknown(Exception e) {
-        return new AnalysisServerException(TYPE.UNKNOWN, e.getMessage(), 400);
+        return new AnalysisServerException(TYPE.UNKNOWN, ExceptionUtils.asString(e), 400);
     }
 
     public static AnalysisServerException unknown(String message) {
@@ -75,7 +72,7 @@ public class AnalysisServerException extends RuntimeException {
 
     public AnalysisServerException(Exception e, String message) {
         this(message);
-        LOG.error(e.getMessage());
+        LOG.error(ExceptionUtils.asString(e));
     }
 
     public AnalysisServerException(String message) {

--- a/src/main/java/com/conveyal/taui/ThreadPool.java
+++ b/src/main/java/com/conveyal/taui/ThreadPool.java
@@ -1,0 +1,14 @@
+package com.conveyal.taui;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Shared unbounded Thread Executor for the entire server to help limit heavy concurrent operations
+ */
+public class ThreadPool {
+    public static final ExecutorService executor = Executors.newFixedThreadPool(AnalysisServerConfig.maxThreads);
+    public static void run (Runnable r) {
+        executor.execute(r);
+    }
+}

--- a/src/main/java/com/conveyal/taui/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BundleController.java
@@ -8,6 +8,7 @@ import com.conveyal.gtfs.api.models.FeedSource;
 import com.conveyal.r5.util.ExceptionUtils;
 import com.conveyal.taui.AnalysisServerConfig;
 import com.conveyal.taui.AnalysisServerException;
+import com.conveyal.taui.ThreadPool;
 import com.conveyal.taui.models.Bundle;
 import com.conveyal.taui.persistence.Persistence;
 import com.conveyal.taui.util.JsonUtil;
@@ -112,7 +113,7 @@ public class BundleController {
         }
 
         // process async
-        new Thread(() -> {
+        ThreadPool.run(() -> {
             try {
                 TDoubleList lats = new TDoubleArrayList();
                 TDoubleList lons = new TDoubleArrayList();
@@ -162,7 +163,7 @@ public class BundleController {
 
             Persistence.bundles.put(bundle);
             directory.delete();
-        }).start();
+        });
 
         return bundle;
     }

--- a/src/main/java/com/conveyal/taui/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BundleController.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.gtfs.api.models.FeedSource;
+import com.conveyal.r5.util.ExceptionUtils;
 import com.conveyal.taui.AnalysisServerConfig;
 import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.models.Bundle;
@@ -52,7 +53,7 @@ public class BundleController {
             bundle.name = files.get("Name").get(0).getString("UTF-8");
             bundle.regionId = files.get("regionId").get(0).getString("UTF-8");
         } catch (Exception e) {
-            throw AnalysisServerException.badRequest(e.getMessage());
+            throw AnalysisServerException.badRequest(ExceptionUtils.asString(e));
         }
 
         bundle.status = Bundle.Status.PROCESSING_GTFS;
@@ -103,7 +104,7 @@ public class BundleController {
             bundleFile.delete();
         } catch (Exception e) {
             bundle.status = Bundle.Status.ERROR;
-            bundle.errorCode = e.getMessage();
+            bundle.errorCode = ExceptionUtils.asString(e);
             Persistence.bundles.put(bundle);
             bundleFile.delete();
 

--- a/src/main/java/com/conveyal/taui/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BundleController.java
@@ -24,13 +24,7 @@ import spark.Response;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static spark.Spark.delete;
@@ -118,73 +112,54 @@ public class BundleController {
 
         // process async
         new Thread(() -> {
-            TDoubleList lats = new TDoubleArrayList();
-            TDoubleList lons = new TDoubleArrayList();
+            try {
+                TDoubleList lats = new TDoubleArrayList();
+                TDoubleList lons = new TDoubleArrayList();
+                Set<String> seenFeedIds = new HashSet<>();
 
-            bundle.feeds = new ArrayList<>();
-            bundle.totalFeeds = localFiles.size();
+                bundle.feeds = new ArrayList<>();
+                bundle.totalFeeds = localFiles.size();
 
-            Map<String, FeedSource> feeds = localFiles.stream()
-                    .map(file -> {
-                        try {
-                            FeedSource fs = ApiMain.registerFeedSource(feed -> String.format("%s_%s", feed.feedId, bundle._id), file);
-                            bundle.feedsComplete += 1;
-                            Persistence.bundles.put(bundle);
-                            return fs;
-                        } catch (Exception e) {
-                            // This catches any error while processing a feed with the GTFS Api and needs to be more
-                            // robust in bubbling up the specific errors to the UI. Really, we need to separate out the
-                            // idea of bundles, track uploads of single feeds at a time, and allow the creation of a
-                            // "bundle" at a later point. This updated error handling is a stopgap until we improve that
-                            // flow.
-                            bundle.status = Bundle.Status.ERROR;
-                            bundle.errorCode = e.getMessage();
-                            Persistence.bundles.put(bundle);
-                            throw AnalysisServerException.unknown(e);
-                        }
-                    })
-                    .collect(Collectors.toMap(f -> f.id, f -> f));
 
-            Set<String> seenFeedIds = new HashSet<>();
+                for (File file : localFiles) {
+                    FeedSource fs = ApiMain.registerFeedSource(feed -> String.format("%s_%s", feed.feedId, bundle._id), file);
+                    if (seenFeedIds.contains(fs.feed.feedId)) {
+                        throw new Exception("Duplicate Feed ID found when uploading bundle");
+                    }
 
-            for (FeedSource fs : feeds.values()) {
-                if (seenFeedIds.contains(fs.feed.feedId)) {
-                    bundle.status = Bundle.Status.ERROR;
-                    bundle.errorCode = "duplicate-feed-_id";
+                    bundle.feeds.add(new Bundle.FeedSummary(fs.feed, bundle._id));
+                    fs.feed.stops.values().forEach(s -> {
+                        lats.add(s.stop_lat);
+                        lons.add(s.stop_lon);
+                    });
+
+                    bundle.feedsComplete += 1;
                     Persistence.bundles.put(bundle);
-                    return;
                 }
 
-                seenFeedIds.add(fs.feed.feedId);
+                // find the median stop location
+                // use a median because it is robust to outliers
+                lats.sort();
+                lons.sort();
+                // not a true median as we don't handle the case when there is an even number of stops
+                // and we are supposed to average the two middle value, but close enough
+                bundle.centerLat = lats.get(lats.size() / 2);
+                bundle.centerLon = lons.get(lons.size() / 2);
 
-                bundle.feeds.add(new Bundle.FeedSummary(fs.feed, bundle));
-
-                fs.feed.stops.values().forEach(s -> {
-                    lats.add(s.stop_lat);
-                    lons.add(s.stop_lon);
-                });
-            }
-
-            // find the median stop location
-            // use a median because it is robust to outliers
-            lats.sort();
-            lons.sort();
-            // not a true median as we don't handle the case when there is an even number of stops
-            // and we are supposed to average the two middle value, but close enough
-            bundle.centerLat = lats.get(lats.size() / 2);
-            bundle.centerLon = lons.get(lons.size() / 2);
-
-            try {
                 bundle.writeManifestToCache();
                 bundle.status = Bundle.Status.DONE;
-            } catch (IOException e) {
-                LOG.error("Error writing bundle manifest to cache", e);
+            } catch (Exception e) {
+                // This catches any error while processing a feed with the GTFS Api and needs to be more
+                // robust in bubbling up the specific errors to the UI. Really, we need to separate out the
+                // idea of bundles, track uploads of single feeds at a time, and allow the creation of a
+                // "bundle" at a later point. This updated error handling is a stopgap until we improve that
+                // flow.
+                LOG.error("Error creating bundle", e);
                 bundle.status = Bundle.Status.ERROR;
-                bundle.errorCode = "cache-write-error";
+                bundle.errorCode = ExceptionUtils.asString(e);
             }
 
             Persistence.bundles.put(bundle);
-
             directory.delete();
         }).start();
 

--- a/src/main/java/com/conveyal/taui/controllers/GraphQLController.java
+++ b/src/main/java/com/conveyal/taui/controllers/GraphQLController.java
@@ -156,7 +156,7 @@ public class GraphQLController {
         ExecutionContext context = (ExecutionContext) environment.getContext();
         return bundle.feeds.stream()
                 .map(summary -> {
-                    String bundleScopedFeedId = String.format("%s_%s", summary.feedId, bundle._id); // : summary.bundleScopedFeedId;
+                    String bundleScopedFeedId = Bundle.bundleScopeFeedId(summary.feedId, bundle._id);
                     try {
                         FeedSource fs = ApiMain.getFeedSource(bundleScopedFeedId);
                         FeedInfo ret;

--- a/src/main/java/com/conveyal/taui/controllers/OpportunityDatasetsController.java
+++ b/src/main/java/com/conveyal/taui/controllers/OpportunityDatasetsController.java
@@ -336,7 +336,7 @@ public class OpportunityDatasetsController {
                 LOG.info("Completed {}/{} uploads for {}", status.uploadedGrids, status.totalGrids, status.name);
             } catch (IOException e) {
                 status.status = Status.ERROR;
-                status.message = e.getMessage();
+                status.message = ExceptionUtils.asString(e);
                 status.completed();
                 throw AnalysisServerException.unknown(e);
             }

--- a/src/main/java/com/conveyal/taui/controllers/RegionController.java
+++ b/src/main/java/com/conveyal/taui/controllers/RegionController.java
@@ -2,6 +2,7 @@ package com.conveyal.taui.controllers;
 
 import com.conveyal.r5.util.ExceptionUtils;
 import com.conveyal.taui.AnalysisServerException;
+import com.conveyal.taui.ThreadPool;
 import com.conveyal.taui.grids.SeamlessCensusGridExtractor;
 import com.conveyal.taui.models.Region;
 import com.conveyal.taui.persistence.OSMPersistence;
@@ -67,7 +68,7 @@ public class RegionController {
 
     public static void fetchOsmAndCensusDataInThread (String _id, Map<String, List<FileItem>> files, boolean newBounds) {
         boolean customOsm = files.containsKey("customOpenStreetMapData");
-        new Thread(() -> {
+        ThreadPool.run(() -> {
             final Region region = Persistence.regions.get(_id);
 
             try {
@@ -105,7 +106,7 @@ public class RegionController {
                 LOG.error("Error while fetching OSM. " + ExceptionUtils.asString(e));
                 e.printStackTrace();
             }
-        }).start();
+        });
     }
 
     public static Region create(Request req, Response res) {

--- a/src/main/java/com/conveyal/taui/controllers/RegionController.java
+++ b/src/main/java/com/conveyal/taui/controllers/RegionController.java
@@ -1,5 +1,6 @@
 package com.conveyal.taui.controllers;
 
+import com.conveyal.r5.util.ExceptionUtils;
 import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.grids.SeamlessCensusGridExtractor;
 import com.conveyal.taui.models.Region;
@@ -48,7 +49,7 @@ public class RegionController {
             ServletFileUpload sfu = new ServletFileUpload(fileItemFactory);
             return sfu.parseParameterMap(req.raw());
         } catch (FileUploadException e) {
-            throw AnalysisServerException.fileUpload("Error uploading files. " + e.getMessage());
+            throw AnalysisServerException.fileUpload("Error uploading files. " + ExceptionUtils.asString(e));
         }
     }
 
@@ -60,7 +61,7 @@ public class RegionController {
 
             return region;
         } catch (IOException e) {
-            throw AnalysisServerException.badRequest("Error parsing region. " + e.getMessage());
+            throw AnalysisServerException.badRequest("Error parsing region. " + ExceptionUtils.asString(e));
         }
     }
 
@@ -98,10 +99,10 @@ public class RegionController {
                 Persistence.regions.put(region);
             } catch (Exception e) {
                 region.statusCode = Region.StatusCode.ERROR;
-                region.statusMessage = "Error while fetching data. " + e.getMessage();
+                region.statusMessage = "Error while fetching data. " + ExceptionUtils.asString(e);
                 Persistence.regions.put(region);
 
-                LOG.error("Error while fetching OSM. " + e.getMessage());
+                LOG.error("Error while fetching OSM. " + ExceptionUtils.asString(e));
                 e.printStackTrace();
             }
         }).start();

--- a/src/main/java/com/conveyal/taui/models/Bundle.java
+++ b/src/main/java/com/conveyal/taui/models/Bundle.java
@@ -42,6 +42,10 @@ public class Bundle extends Model implements Cloneable {
 
     public String errorCode;
 
+    public static String bundleScopeFeedId (String feedId, String bundleId) {
+        return String.format("%s_%s", feedId, bundleId);
+    }
+
     private static final AmazonS3 s3 = new AmazonS3Client();
 
     public void writeManifestToCache () throws IOException {
@@ -80,9 +84,9 @@ public class Bundle extends Model implements Cloneable {
         public LocalDate serviceEnd;
         public long checksum;
 
-        public FeedSummary(GTFSFeed feed, Bundle bundle) {
+        public FeedSummary(GTFSFeed feed, String bundleId) {
             feedId = feed.feedId;
-            bundleScopedFeedId = String.format("%s_%s", feed.feedId, bundle._id);
+            bundleScopedFeedId = bundleScopeFeedId(feed.feedId, bundleId);
             name = feed.agency.size() > 0 ? feed.agency.values().iterator().next().agency_name : feed.feedId;
             checksum = feed.checksum;
         }

--- a/src/main/java/com/conveyal/taui/models/ModificationStop.java
+++ b/src/main/java/com/conveyal/taui/models/ModificationStop.java
@@ -1,6 +1,7 @@
 package com.conveyal.taui.models;
 
 import com.conveyal.r5.analyst.scenario.StopSpec;
+import com.conveyal.r5.util.ExceptionUtils;
 import com.conveyal.taui.AnalysisServerException;
 import com.vividsolutions.jts.geom.Coordinate;
 import org.geotools.geometry.jts.JTS;
@@ -76,7 +77,7 @@ class ModificationStop {
                 try {
                     distanceThisLineSegment = JTS.orthodromicDistance(c0, c1, crs);
                 } catch (TransformException e) {
-                    throw AnalysisServerException.unknown(e.getMessage());
+                    throw AnalysisServerException.unknown(ExceptionUtils.asString(e));
                 }
 
                 if (spacing > 0) {


### PR DESCRIPTION
Wrap more of the bundle uploading with a try/catch loop to be able to detect more failures and update the status correctly when that occurs. Also store and return more verbose error messages.

This also replaces `e.getMessage` with R5's `ExceptionUtils.asString` throughout most of the project.