### PR TITLE
Store service start and end dates in bundles

### DIFF
--- a/src/main/java/com/conveyal/taui/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BundleController.java
@@ -158,7 +158,9 @@ public class BundleController {
                     }
 
                     bundle.feedsComplete += 1;
-                    Persistence.bundles.put(bundle);
+
+                    // Done in a loop the nonce and updatedAt would be changed repeatedly
+                    Persistence.bundles.modifiyWithoutUpdatingLock(bundle);
                 }
 
                 // TODO Handle crossing the antimeridian
@@ -239,7 +241,7 @@ public class BundleController {
      * @param bundle
      */
     public static Bundle setBundleServiceDates (Bundle bundle) throws Exception {
-        if (bundle.status == Bundle.Status.DONE && bundle.serviceStart != null && bundle.serviceEnd != null) return bundle;
+        if (bundle.status != Bundle.Status.DONE || (bundle.serviceStart != null && bundle.serviceEnd != null)) return bundle;
 
         // Old bundles were created with computing the service start and end dates
         bundle.serviceStart = LocalDate.MAX;
@@ -265,7 +267,7 @@ public class BundleController {
         }
 
         // Automated change that could occur on a `get`, so don't update the nonce
-        return Persistence.bundles.put(bundle);
+        return Persistence.bundles.modifiyWithoutUpdatingLock(bundle);
     }
 
     public static void register () {

--- a/src/main/java/com/conveyal/taui/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BundleController.java
@@ -167,9 +167,6 @@ public class BundleController {
                 bundle.east = bundleBounds.getMaxX();
                 bundle.west = bundleBounds.getMinX();
 
-                bundle.centerLat = (bundle.north + bundle.south) / 2;
-                bundle.centerLon = (bundle.west + bundle.east) / 2;
-
                 writeManifestToCache(bundle);
                 bundle.status = Bundle.Status.DONE;
             } catch (Exception e) {

--- a/src/main/java/com/conveyal/taui/controllers/GraphQLController.java
+++ b/src/main/java/com/conveyal/taui/controllers/GraphQLController.java
@@ -161,31 +161,31 @@ public class GraphQLController {
         }
 
         return bundle.feeds.stream()
-            .map(summary -> {
-                String bundleScopedFeedId = Bundle.bundleScopeFeedId(summary.feedId, bundle._id);
-                try {
-                    FeedSource fs = ApiMain.getFeedSource(bundleScopedFeedId);
-                    FeedInfo ret;
-                    if (fs != null && fs.feed.feedInfo.size() > 0)
-                        ret = fs.feed.feedInfo.values().iterator().next();
-                    else {
-                        ret = new FeedInfo();
+                .map(summary -> {
+                    String bundleScopedFeedId = Bundle.bundleScopeFeedId(summary.feedId, bundle._id);
+                    try {
+                        FeedSource fs = ApiMain.getFeedSource(bundleScopedFeedId);
+                        FeedInfo ret;
+                        if (fs != null && fs.feed.feedInfo.size() > 0)
+                            ret = fs.feed.feedInfo.values().iterator().next();
+                        else {
+                            ret = new FeedInfo();
+                        }
+                        if (ret.feed_id == null || "NONE".equals(ret.feed_id)) {
+                            ret = ret.clone();
+                            ret.feed_id = fs.feed.feedId;
+                        }
+                        return new WrappedFeedInfo(summary.bundleScopedFeedId, ret, summary.checksum);
+                    } catch (UncheckedExecutionException nsee) {
+                        Exception e = new Exception(String.format("Feed %s does not exist in the cache.", summary.name), nsee);
+                        context.addError(new ExceptionWhileDataFetching(e));
+                        return null;
+                    } catch (Exception e) {
+                        context.addError(new ExceptionWhileDataFetching(e));
+                        return null;
                     }
-                    if (ret.feed_id == null || "NONE".equals(ret.feed_id)) {
-                        ret = ret.clone();
-                        ret.feed_id = fs.feed.feedId;
-                    }
-                    return new WrappedFeedInfo(summary.bundleScopedFeedId, ret, summary.checksum);
-                } catch (UncheckedExecutionException nsee) {
-                    Exception e = new Exception(String.format("Feed %s does not exist in the cache.", summary.name), nsee);
-                    context.addError(new ExceptionWhileDataFetching(e));
-                    return null;
-                } catch (Exception e) {
-                    context.addError(new ExceptionWhileDataFetching(e));
-                    return null;
-                }
-            })
-            .collect(Collectors.toList());
+                })
+                .collect(Collectors.toList());
     }
 
     public static void register () {

--- a/src/main/java/com/conveyal/taui/controllers/GraphQLController.java
+++ b/src/main/java/com/conveyal/taui/controllers/GraphQLController.java
@@ -29,10 +29,10 @@ import spark.Request;
 import spark.Response;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.conveyal.gtfs.api.graphql.GraphQLGtfsSchema.routeType;
 import static com.conveyal.gtfs.api.graphql.GraphQLGtfsSchema.stopType;
@@ -79,6 +79,8 @@ public class GraphQLController {
             .field(string("feed_publisher_url"))
             .field(string("feed_lang"))
             .field(string("feed_version"))
+            .field(string("feed_start_date"))
+            .field(string("feed_end_date"))
             // We have a custom wrapped GTFS Entity type for FeedInfo that includes feed checksum
             .field(newFieldDefinition()
                     .name("checksum")
@@ -154,37 +156,45 @@ public class GraphQLController {
     private static List<WrappedGTFSEntity<FeedInfo>> fetchFeeds(DataFetchingEnvironment environment) {
         Bundle bundle = (Bundle) environment.getSource();
         ExecutionContext context = (ExecutionContext) environment.getContext();
-        return bundle.feeds.stream()
-                .map(summary -> {
-                    String bundleScopedFeedId = Bundle.bundleScopeFeedId(summary.feedId, bundle._id);
-                    try {
-                        FeedSource fs = ApiMain.getFeedSource(bundleScopedFeedId);
-                        FeedInfo ret;
-                        if (fs != null && fs.feed.feedInfo.size() > 0)
-                            ret = fs.feed.feedInfo.values().iterator().next();
-                        else {
-                            ret = new FeedInfo();
-                        }
 
-                        if (ret.feed_id == null || "NONE".equals(ret.feed_id)) {
-                            ret = ret.clone();
-                            ret.feed_id = fs.feed.feedId;
-                        }
+        // Old bundles were created without computing the service start and end dates. Will only compute if needed.
+        try {
+            BundleController.setBundleServiceDates(bundle);
+        } catch (Exception e) {
+            context.addError(new ExceptionWhileDataFetching(e));
+        }
 
-                        return new WrappedFeedInfo(summary.bundleScopedFeedId, ret, summary.checksum);
-                    } catch (UncheckedExecutionException nsee) {
-                        Exception e = new Exception(String.format("Feed %s does not exist in the cache.", summary.name), nsee);
-                        context.addError(new ExceptionWhileDataFetching(e));
-                        return null;
-                    } catch (Exception e) {
-                        context.addError(new ExceptionWhileDataFetching(e));
-                        return null;
-                    }
-                })
-                .collect(Collectors.toList());
+        List<WrappedGTFSEntity<FeedInfo>> feeds = new ArrayList<>();
+        for (Bundle.FeedSummary summary : bundle.feeds) {
+            String bundleScopedFeedId = Bundle.bundleScopeFeedId(summary.feedId, bundle._id);
+            try {
+                FeedSource fs = ApiMain.getFeedSource(bundleScopedFeedId);
+                FeedInfo ret;
+                if (fs != null && fs.feed.feedInfo.size() > 0) {
+                    ret = fs.feed.feedInfo.values().iterator().next();
+                } else {
+                    ret = new FeedInfo();
+                }
+
+                if (ret.feed_id == null || "NONE".equals(ret.feed_id)) {
+                    ret = ret.clone();
+                    ret.feed_id = fs.feed.feedId;
+                }
+
+                feeds.add(new WrappedFeedInfo(summary.bundleScopedFeedId, ret, summary.checksum));
+            } catch (UncheckedExecutionException nsee) {
+                Exception e = new Exception(String.format("Feed %s does not exist in the cache.", summary.name), nsee);
+                context.addError(new ExceptionWhileDataFetching(e));
+            } catch (Exception e) {
+                context.addError(new ExceptionWhileDataFetching(e));
+            }
+        }
+
+        return feeds;
     }
 
     public static void register () {
+        // TODO make this `post` as per GraphQL convention
         get("/api/graphql", GraphQLController::handleQuery, JsonUtil.objectMapper::writeValueAsString);
     }
 

--- a/src/main/java/com/conveyal/taui/controllers/ProjectController.java
+++ b/src/main/java/com/conveyal/taui/controllers/ProjectController.java
@@ -153,7 +153,12 @@ public class ProjectController {
         return Persistence.projects.removeIfPermitted(req.params("_id"), req.attribute("accessGroup"));
     }
 
+    public static Collection<Project> getProjects (Request req, Response res) {
+        return Persistence.projects.findPermittedForQuery(req);
+    }
+
     public static void register () {
+        get("/api/project", ProjectController::getProjects, JsonUtil.objectMapper::writeValueAsString);
         get("/api/project/:_id", ProjectController::findById, JsonUtil.objectMapper::writeValueAsString);
         get("/api/project/:_id/modifications", ProjectController::modifications, JsonUtil.objectMapper::writeValueAsString);
         post("/api/project/:_id/import/:_importId", ProjectController::importModifications, JsonUtil.objectMapper::writeValueAsString);

--- a/src/main/java/com/conveyal/taui/controllers/TimetableController.java
+++ b/src/main/java/com/conveyal/taui/controllers/TimetableController.java
@@ -15,6 +15,7 @@ import spark.Request;
 import spark.Response;
 
 import java.util.Collection;
+import java.util.List;
 
 import static spark.Spark.get;
 
@@ -33,15 +34,15 @@ public class TimetableController {
             r.put("_id", region._id);
             r.put("name", region.name);
             JSONArray regionProjects = new JSONArray();
-            for (Project project : region.getProjects()) {
+            List<Project> projects = Persistence.projects.find(QueryBuilder.start("regionId").is(region._id).get()).toArray();
+            for (Project project : projects) {
                 JSONObject p = new JSONObject();
                 p.put("_id", project._id);
                 p.put("name", project.name);
                 JSONArray projectModifications = new JSONArray();
-                Collection<Modification> modifications = Persistence.modifications.findPermitted(
-                    QueryBuilder.start("projectId").is(project._id).and("type").is("add-trip-pattern").get(),
-                    req.attribute("accessGroup")
-                );
+                List<Modification> modifications = Persistence.modifications.find(
+                        QueryBuilder.start("projectId").is(project._id).and("type").is("add-trip-pattern").get()
+                ).toArray();
                 for (Modification modification : modifications) {
                     AddTripPattern tripPattern = (AddTripPattern) modification;
                     JSONObject m = new JSONObject();

--- a/src/main/java/com/conveyal/taui/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/taui/models/AnalysisRequest.java
@@ -32,6 +32,7 @@ public class AnalysisRequest {
     // All analyses parameters
     public String accessModes;
     public float bikeSpeed;
+    public Bounds bounds;
     public LocalDate date;
     public String directModes;
     public String egressModes;
@@ -57,7 +58,6 @@ public class AnalysisRequest {
     public int suboptimalMinutes = 5;
 
     // Regional only
-    public Bounds bounds;
     public Integer maxTripDurationMinutes;
     public String name;
     public String opportunityDatasetId;
@@ -119,17 +119,12 @@ public class AnalysisRequest {
         }
 
         // TODO define class with static factory function WebMercatorGridBounds.fromLatLonBounds(). Also include getIndex(x, y), getX(index), getY(index), totalTasks()
-
-        int east = Grid.lonToPixel(bounds.east, ZOOM);
-        int north = Grid.latToPixel(bounds.north, ZOOM);
-        int south = Grid.latToPixel(bounds.south, ZOOM);
-        int west = Grid.lonToPixel(bounds.west, ZOOM);
-
-        task.height = south - north;
-        task.north = north;
-        task.west = west;
-        task.width = east - west;
-        task.zoom = ZOOM;
+        Grid grid = new Grid(ZOOM, bounds.north, bounds.east, bounds.south, bounds.west);
+        task.height = grid.height;
+        task.north = grid.north;
+        task.west = grid.west;
+        task.width = grid.width;
+        task.zoom = grid.zoom;
 
         task.date = date;
         task.fromLat = fromLat;

--- a/src/main/java/com/conveyal/taui/models/Bundle.java
+++ b/src/main/java/com/conveyal/taui/models/Bundle.java
@@ -20,7 +20,7 @@ public class Bundle extends Model implements Cloneable {
     public double south;
     public double east;
     public double west;
-    
+
     public LocalDate serviceStart;
     public LocalDate serviceEnd;
 

--- a/src/main/java/com/conveyal/taui/models/Bundle.java
+++ b/src/main/java/com/conveyal/taui/models/Bundle.java
@@ -1,19 +1,11 @@
 package com.conveyal.taui.models;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.conveyal.gtfs.GTFSCache;
 import com.conveyal.gtfs.GTFSFeed;
-import com.conveyal.r5.analyst.cluster.BundleManifest;
-import com.conveyal.taui.AnalysisServerConfig;
 import com.conveyal.taui.AnalysisServerException;
-import com.conveyal.taui.util.JsonUtil;
 
-import java.io.File;
-import java.io.IOException;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Represents a transport bundle (GTFS and OSM).
@@ -72,10 +64,18 @@ public class Bundle extends Model implements Cloneable {
             bundleScopedFeedId = bundleScopeFeedId(feed.feedId, bundleId);
             name = feed.agency.size() > 0 ? feed.agency.values().iterator().next().agency_name : feed.feedId;
             checksum = feed.checksum;
+
+            // Set service start and end from the dates of service
+            List<LocalDate> datesOfService = feed.getDatesOfService();
+            datesOfService.sort(Comparator.naturalOrder());
+            serviceStart = datesOfService.get(0);
+            serviceEnd = datesOfService.get(datesOfService.size() - 1);
         }
 
-        /** restore default constructor for use in deserialization */
-        public FeedSummary () { /* do nothing */ }
+        /**
+         * Default empty constructor needed for JSON mapping
+         */
+        public FeedSummary () { }
 
         public FeedSummary clone () {
             try {

--- a/src/main/java/com/conveyal/taui/models/Bundle.java
+++ b/src/main/java/com/conveyal/taui/models/Bundle.java
@@ -20,10 +20,7 @@ public class Bundle extends Model implements Cloneable {
     public double south;
     public double east;
     public double west;
-
-    public double centerLat;
-    public double centerLon;
-
+    
     public LocalDate serviceStart;
     public LocalDate serviceEnd;
 

--- a/src/main/java/com/conveyal/taui/models/Bundle.java
+++ b/src/main/java/com/conveyal/taui/models/Bundle.java
@@ -4,6 +4,7 @@ import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.taui.AnalysisServerException;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -26,7 +27,7 @@ public class Bundle extends Model implements Cloneable {
     public LocalDate serviceStart;
     public LocalDate serviceEnd;
 
-    public List<FeedSummary> feeds;
+    public List<FeedSummary> feeds = new ArrayList<>();
     public Status status;
 
     public int feedsComplete;

--- a/src/main/java/com/conveyal/taui/models/Bundle.java
+++ b/src/main/java/com/conveyal/taui/models/Bundle.java
@@ -60,13 +60,17 @@ public class Bundle extends Model implements Cloneable {
         public LocalDate serviceEnd;
         public long checksum;
 
+        /**
+         * Set service start and end from the dates of service values returned from GTFSFeed. This is calculated from
+         * the trip data in the feed. Feed summaries (feed_start_date/feed_end_date) are not always included in feeds.
+         */
         public FeedSummary(GTFSFeed feed, String bundleId) {
             feedId = feed.feedId;
             bundleScopedFeedId = bundleScopeFeedId(feed.feedId, bundleId);
             name = feed.agency.size() > 0 ? feed.agency.values().iterator().next().agency_name : feed.feedId;
             checksum = feed.checksum;
 
-            // Set service start and end from the dates of service
+
             List<LocalDate> datesOfService = feed.getDatesOfService();
             datesOfService.sort(Comparator.naturalOrder());
             serviceStart = datesOfService.get(0);

--- a/src/main/java/com/conveyal/taui/models/Region.java
+++ b/src/main/java/com/conveyal/taui/models/Region.java
@@ -29,21 +29,6 @@ public class Region extends Model implements Cloneable {
     public StatusCode statusCode;
     public String statusMessage;
 
-    /* don't persist to DB but do expose to API */
-    @JsonView(JsonViews.Api.class)
-    public List<Bundle> getBundles () {
-        return Persistence.bundles
-                .find(QueryBuilder.start("regionId").is(_id).get())
-                .toArray();
-    }
-
-    @JsonView(JsonViews.Api.class)
-    public List<Project> getProjects () {
-        return Persistence.projects
-                .find(QueryBuilder.start("regionId").is(_id).get())
-                .toArray();
-    }
-
     @JsonView(JsonViews.Api.class)
     public Collection<Bookmark> getBookmarks () {
         return Persistence.bookmarks.getByProperty("regionId", _id);

--- a/src/main/java/com/conveyal/taui/models/Region.java
+++ b/src/main/java/com/conveyal/taui/models/Region.java
@@ -3,11 +3,8 @@ package com.conveyal.taui.models;
 import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.persistence.Persistence;
 import com.fasterxml.jackson.annotation.JsonView;
-import com.mongodb.QueryBuilder;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Represents a region, which is a set of GTFS, OSM, and land use data for a particular location.
@@ -28,6 +25,7 @@ public class Region extends Model implements Cloneable {
     /** Load status of this region */
     public StatusCode statusCode;
     public String statusMessage;
+
 
     @JsonView(JsonViews.Api.class)
     public Collection<Bookmark> getBookmarks () {

--- a/src/main/java/com/conveyal/taui/persistence/MongoMap.java
+++ b/src/main/java/com/conveyal/taui/persistence/MongoMap.java
@@ -188,6 +188,16 @@ public class MongoMap<V extends Model> {
         return result;
     }
 
+    /**
+     * Insert without updating the nonce or updateBy/updatedAt
+     * @return
+     */
+    public V modifiyWithoutUpdatingLock (V value) {
+        wrappedCollection.updateById(value._id, value);
+
+        return value;
+    }
+
     public V removeIfPermitted(String key, String accessGroup) {
         V result = wrappedCollection.findAndRemove(QueryBuilder.start().and(
                 QueryBuilder.start("_id").is(key).get(),

--- a/src/main/java/com/conveyal/taui/persistence/MongoMap.java
+++ b/src/main/java/com/conveyal/taui/persistence/MongoMap.java
@@ -16,12 +16,10 @@ import org.slf4j.LoggerFactory;
 import spark.Request;
 
 import java.io.IOException;
-import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -73,6 +71,15 @@ public class MongoMap<V extends Model> {
                 query,
                 QueryBuilder.start("accessGroup").is(accessGroup).get()
         ).get()).toArray();
+    }
+
+    public Collection<V> findPermittedForQuery (Request req) {
+        QueryBuilder query = QueryBuilder.start();
+        req.queryParams().forEach(name -> {
+            query.and(name).is(req.queryParams(name));
+        });
+
+        return findPermitted(query.get(), req.attribute("accessGroup"));
     }
 
     /**


### PR DESCRIPTION
Calculate service start and end dates based off of `GTFSFeed.getDatesOfService()`. These dates are currently only used to show the user if there is any service on a given date and warn if there is not. A user should know the contents of their GTFS feeds they've uploaded, but this will warn them when they have a date set that does not contain ANY service.

This PR also adds API endpoints for loading bundles and projects that no longer get automatically fetched when retrieving a region.

Requires https://github.com/conveyal/analysis-ui/pull/770