### PR TITLE
Fix NPE that was thrown when the feed ids array was null.

### DIFF
--- a/src/main/java/com/conveyal/taui/models/Modification.java
+++ b/src/main/java/com/conveyal/taui/models/Modification.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -41,6 +42,7 @@ public abstract class Modification extends Model implements Cloneable {
     public String description;
 
     public Set<String> feedScopeIds (String feed, String[] ids) {
+        if (ids == null) return new HashSet<>();
         return Arrays.stream(ids).map(id -> feedScopeId(feed, id)).collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
This just returns an empty `Set<String>` instead. Which should enable the request to make it to R5 and return with an appropriate error/warning. Right now users are getting a vague error when modifications are not fully filled out.
