### PR TITLE
Preserve content-type when proxying to workers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>r5</artifactId>
-            <version>4.2.0</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/conveyal/taui/AnalysisServer.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServer.java
@@ -5,7 +5,6 @@ import com.conveyal.gtfs.api.ApiMain;
 import com.conveyal.gtfs.api.util.FeedSourceCache;
 import com.conveyal.r5.util.ExceptionUtils;
 import com.conveyal.taui.analysis.LocalCluster;
-import com.conveyal.taui.analysis.broker.Broker;
 import com.conveyal.taui.controllers.AggregationAreaController;
 import com.conveyal.taui.controllers.BundleController;
 import com.conveyal.taui.controllers.GraphQLController;
@@ -15,7 +14,7 @@ import com.conveyal.taui.controllers.ProjectController;
 import com.conveyal.taui.controllers.RegionController;
 import com.conveyal.taui.controllers.RegionalAnalysisController;
 import com.conveyal.taui.controllers.TimetableController;
-import com.conveyal.taui.controllers.WorkerController;
+import com.conveyal.taui.controllers.BrokerController;
 import com.conveyal.taui.persistence.OSMPersistence;
 import com.conveyal.taui.persistence.Persistence;
 import com.google.common.io.CharStreams;
@@ -111,7 +110,7 @@ public class AnalysisServer {
 //        httpService.redirect.any("/hi", "/hello");
 
         // TODO pass in non-static Analysis server config
-        new WorkerController(RegionalAnalysisController.broker).register();
+        new BrokerController(RegionalAnalysisController.broker).register();
 
         // Load index.html and register a handler with Spark to serve it up.
         InputStream indexStream = AnalysisServer.class.getClassLoader().getResourceAsStream("public/index.html");


### PR DESCRIPTION
This is necessary for conveyal/r5#459 to work properly.
The workers can generate responses in several formats including GeoTIFF, proprietary binary grid, or JSON. We want to preserve that information when the response is repeated by the broker back to the UI. 

