### PR TITLE
Update the mongodb-java-driver to support secure remote connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>3.2.1</version>
+            <version>3.8.2</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/conveyal/taui/persistence/Persistence.java
+++ b/src/main/java/com/conveyal/taui/persistence/Persistence.java
@@ -44,8 +44,7 @@ public class Persistence {
         LOG.info("Connecting to MongoDB...");
         if (AnalysisServerConfig.databaseUri != null) {
             LOG.info("Connecting to remote MongoDB instance...");
-            MongoClientOptions.Builder builder = MongoClientOptions.builder().sslEnabled(true);
-            mongo = new MongoClient(new MongoClientURI(AnalysisServerConfig.databaseUri, builder));
+            mongo = new MongoClient(new MongoClientURI(AnalysisServerConfig.databaseUri));
         } else {
             LOG.info("Connecting to local MongoDB instance...");
             mongo = new MongoClient();


### PR DESCRIPTION
* Updates the driver to v3.8.2 (which includes support for MongoDB 4)
* Removes the forced `ssl` enabled option because that can be specified in the URI.

Addresses #100 
