### PR TITLE
EC2 Enhancements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>r5</artifactId>
-            <version>4.5.0</version>
+            <version>4.5.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
@@ -99,9 +99,11 @@ public class Broker {
 
         this.workOffline = AnalysisServerConfig.offline;
 
-        this.maxWorkers = AnalysisServerConfig.maxWorkers;
+        if (!workOffline){
+            this.launcher = new EC2Launcher();
+        }
 
-        this.launcher = new EC2Launcher();
+        this.maxWorkers = AnalysisServerConfig.maxWorkers;
 
     }
 

--- a/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
@@ -5,6 +5,7 @@ import com.conveyal.r5.analyst.cluster.RegionalTask;
 import com.conveyal.r5.analyst.cluster.RegionalWorkResult;
 import com.conveyal.r5.analyst.cluster.WorkerStatus;
 import com.conveyal.taui.AnalysisServerConfig;
+import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.GridResultAssembler;
 import com.conveyal.taui.analysis.RegionalAnalysisStatus;
 import com.google.common.collect.ListMultimap;
@@ -159,8 +160,8 @@ public class Broker {
         }
 
         if (workerCatalog.totalWorkerCount() >= maxWorkers) {
-            LOG.warn("{} workers already started, not starting more; jobs will not complete on {}", maxWorkers, category);
-            return;
+            throw AnalysisServerException.forbidden("\"{} workers already started, not starting more; jobs will not " +
+                    "complete on {}\", maxWorkers, category");
         }
 
         // If workers have already been started up, don't repeat the operation.
@@ -174,7 +175,7 @@ public class Broker {
 
         launcher.launch(config, nOnDemand, nSpot);
 
-        // Record the fact that we've requested this kind of workers so we don't do it repeatedly.
+        // Record the fact that we've requested an on-demand worker so we don't do it repeatedly.
         if (nOnDemand > 0) {
             recentlyRequestedWorkers.put(category, System.currentTimeMillis());
         }

--- a/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
@@ -129,7 +129,7 @@ public class Broker {
             return;
         }
         if (workerCatalog.noWorkersAvailable(job.workerCategory, workOffline)) {
-            createWorkersInCategory(job.workerCategory, accessGroup, createdBy);
+            createOnDemandWorkerInCategory(job.workerCategory, accessGroup, createdBy);
         } else {
             // Workers exist in this category, clear out any record that we're waiting for one to start up.
             recentlyRequestedWorkers.remove(job.workerCategory);
@@ -141,7 +141,7 @@ public class Broker {
      * @param user only used to tag the newly created instance
      * @param group only used to tag the newly created instance
      */
-    public void createWorkersInCategory (WorkerCategory category, String group, String user){
+    public void createOnDemandWorkerInCategory(WorkerCategory category, String group, String user){
         createWorkersInCategory(category, group, user, 1, 0);
     }
 

--- a/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
@@ -181,7 +181,7 @@ public class Broker {
         if (nOnDemand > 0) {
             recentlyRequestedWorkers.put(category, System.currentTimeMillis());
         }
-        LOG.info("Requested {} on-demand and {} spot workers on {}", nOnDemand, config);
+        LOG.info("Requested {} on-demand and {} spot workers on {}", nOnDemand, nSpot, config);
     }
 
     /**

--- a/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
@@ -66,14 +66,14 @@ public class Broker {
 
     /** Used when auto-starting spot instances. Set to a smaller value to increase the number of workers requested
      * automatically*/
-    public final int TARGET_TOTAL_TASKS_PER_WORKER = 10_000;
+    public final int TARGET_TOTAL_TASKS_PER_WORKER = 2_000;
 
     /** We want to request spot instances to "boost" regional analyses after a few regional tasks have been received
      * for a given network. Do so after receiving results for an arbitrary task*/
     public final int AUTO_START_SPOT_INSTANCES_AT_TASK  = MAX_TASKS_PER_WORKER * 2 + 10; //42
 
     /** The maximum number of spot instances allowable in an automatic request */
-    public final int MAX_WORKERS_PER_CATEGORY = 50;
+    public final int MAX_WORKERS_PER_CATEGORY = 75;
 
     /**
      * How long to give workers to start up (in ms) before assuming that they have started (and starting more

--- a/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
@@ -138,7 +138,7 @@ public class Broker {
      * @param user only used to tag the newly created instance
      * @param group only used to tag the newly created instance
      */
-    public synchronized void createWorkersInCategory (WorkerCategory category, String group, String user){
+    public void createWorkersInCategory (WorkerCategory category, String group, String user){
         createWorkersInCategory(category, group, user, 1, 0);
     }
 

--- a/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
@@ -10,6 +10,7 @@ import com.conveyal.taui.GridResultAssembler;
 import com.conveyal.taui.analysis.RegionalAnalysisStatus;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
+import gnu.trove.TCollections;
 import gnu.trove.map.TObjectLongMap;
 import gnu.trove.map.hash.TObjectLongHashMap;
 import org.slf4j.Logger;
@@ -91,7 +92,8 @@ public class Broker {
      * keep track of which graphs we have launched workers on and how long ago we launched them,
      * so that we don't re-request workers which have been requested.
      */
-    public TObjectLongMap<WorkerCategory> recentlyRequestedWorkers = new TObjectLongHashMap<>();
+    public TObjectLongMap<WorkerCategory> recentlyRequestedWorkers = TCollections.synchronizedMap(new
+            TObjectLongHashMap<>());
 
     public Broker () {
         // print out date on startup so that CloudWatch logs has a unique fingerprint
@@ -153,7 +155,7 @@ public class Broker {
      * @param nSpot EC2 spot instances to request
      */
 
-    public synchronized void createWorkersInCategory (WorkerCategory category, String group, String user, int
+    public void createWorkersInCategory (WorkerCategory category, String group, String user, int
             nOnDemand, int nSpot) {
 
         if (workOffline) {

--- a/src/main/java/com/conveyal/taui/analysis/broker/EC2Launcher.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/EC2Launcher.java
@@ -44,7 +44,7 @@ public class EC2Launcher {
 
     }
 
-    public synchronized void launch (EC2RequestConfiguration requestConfig, int nOnDemand, int nSpot) {
+    public void launch (EC2RequestConfiguration requestConfig, int nOnDemand, int nSpot) {
 
         if (nOnDemand > 0){
 

--- a/src/main/java/com/conveyal/taui/analysis/broker/EC2Launcher.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/EC2Launcher.java
@@ -1,0 +1,82 @@
+package com.conveyal.taui.analysis.broker;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+import com.amazonaws.services.ec2.model.RequestSpotInstancesRequest;
+import com.amazonaws.services.ec2.model.RequestSpotInstancesResult;
+import com.amazonaws.services.ec2.model.RunInstancesRequest;
+import com.amazonaws.services.ec2.model.RunInstancesResult;
+import com.conveyal.taui.AnalysisServerConfig;
+import com.conveyal.taui.ExecutorServices;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AWS SDK client to launch EC2 fleets.  Should be initialized once (in Broker)
+ */
+
+public class EC2Launcher {
+    private static final Logger LOG = LoggerFactory.getLogger(EC2Launcher.class);
+
+    /** Amazon AWS SDK client. */
+    private AmazonEC2 ec2;
+
+    EC2Launcher(){
+
+        AmazonEC2ClientBuilder ec2Builder = AmazonEC2ClientBuilder.standard();
+
+        // When running on an EC2 instance, default to the AWS region of that instance
+        Region region = null;
+        if (!AnalysisServerConfig.offline) {
+            region = Regions.getCurrentRegion();
+        }
+        if (region != null) {
+            ec2Builder.setRegion(region.getName());
+        } else {
+            ec2Builder.withRegion(AnalysisServerConfig.awsRegion);
+        }
+        ec2 = ec2Builder.build();
+
+    }
+
+    public synchronized void launch (EC2RequestConfiguration requestConfig, int nOnDemand, int nSpot) {
+
+        if (nOnDemand > 0){
+
+            LOG.info("Requesting {} on-demand workers on {}", nOnDemand, requestConfig);
+
+            String clientToken = UUID.randomUUID().toString().replaceAll("-", "");
+
+            RunInstancesRequest onDemandRequest = requestConfig.prepareOnDemandRequest()
+                    .withMinCount(1)
+                    .withMaxCount(nOnDemand)
+                    .withClientToken(clientToken);
+
+            ExecutorServices.light.execute(() -> {
+                RunInstancesResult res = ec2.runInstances(onDemandRequest);
+                // TODO check and log result of request.
+            });
+        }
+
+        if (nSpot > 0){
+
+            LOG.info("Requesting {} spot workers on {}", nSpot, requestConfig);
+
+            String clientToken = UUID.randomUUID().toString().replaceAll("-", "");
+
+            RequestSpotInstancesRequest spotRequest = requestConfig.prepareSpotRequest()
+                    .withInstanceCount(nSpot)
+                    .withClientToken(clientToken);
+
+            ExecutorServices.light.execute(() -> {
+                RequestSpotInstancesResult res = ec2.requestSpotInstances(spotRequest);
+                // TODO check and log result of request.
+            });
+        }
+    }
+}

--- a/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
@@ -27,8 +27,8 @@ public class EC2RequestConfiguration {
     private Properties workerConfig;
 
     @Override
-    public String toString(){
-        return (String.format("%s for %s (%s)", workerConfig, user, group));
+    public String toString() {
+        return workerConfig.toString() + "for " + user + "(" + group +")";
     }
 
     EC2RequestConfiguration(WorkerCategory category, String group, String user) {

--- a/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
@@ -28,7 +28,7 @@ public class EC2RequestConfiguration {
 
     @Override
     public String toString() {
-        return workerConfig.toString() + "for " + user + "(" + group +")";
+        return String.format("%s for %s (%s)", category, user, group);
     }
 
     EC2RequestConfiguration(WorkerCategory category, String group, String user) {

--- a/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
@@ -1,0 +1,127 @@
+package com.conveyal.taui.analysis.broker;
+
+import com.amazonaws.services.ec2.model.IamInstanceProfileSpecification;
+import com.amazonaws.services.ec2.model.LaunchSpecification;
+import com.amazonaws.services.ec2.model.RequestSpotInstancesRequest;
+import com.amazonaws.services.ec2.model.ResourceType;
+import com.amazonaws.services.ec2.model.RunInstancesRequest;
+import com.amazonaws.services.ec2.model.ShutdownBehavior;
+import com.amazonaws.services.ec2.model.Tag;
+import com.amazonaws.services.ec2.model.TagSpecification;
+import com.conveyal.r5.analyst.WorkerCategory;
+import com.conveyal.taui.AnalysisServerConfig;
+import com.google.common.io.ByteStreams;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.MessageFormat;
+import java.util.Base64;
+import java.util.Properties;
+
+public class EC2RequestConfiguration {
+    private WorkerCategory category;
+    private String group;
+    private String user;
+    private String userDataScript;
+    private Properties workerConfig;
+
+    @Override
+    public String toString(){
+        return (String.format("%s for %s (%s)", workerConfig, user, group));
+    }
+
+    EC2RequestConfiguration(WorkerCategory category, String group, String user) {
+        this.category = category;
+        this.group = group;
+        this.user = user;
+
+        if (!AnalysisServerConfig.offline) {
+            workerConfig = new Properties();
+            // TODO rename to worker-log-group in worker code
+            workerConfig.setProperty("log-group", AnalysisServerConfig.workerLogGroup);
+            workerConfig.setProperty("broker-address", AnalysisServerConfig.serverAddress);
+            // TODO rename all config fields in config class, worker and backend to be consistent.
+            // TODO Maybe just send the entire analyst config to the worker!
+            workerConfig.setProperty("broker-port", Integer.toString(AnalysisServerConfig.serverPort));
+            workerConfig.setProperty("worker-port", Integer.toString(AnalysisServerConfig.workerPort));
+            workerConfig.setProperty("graphs-bucket", AnalysisServerConfig.bundleBucket);
+            workerConfig.setProperty("pointsets-bucket", AnalysisServerConfig.gridBucket);
+            workerConfig.setProperty("aws-region", AnalysisServerConfig.awsRegion);
+            // Tell the workers to shut themselves down automatically when no longer busy.
+            workerConfig.setProperty("auto-shutdown", "true");
+            workerConfig.setProperty("initial-graph-id", category.graphId);
+        }
+
+        // Substitute details into the startup script
+        // We used to just pass the config to custom AMI, but by constructing a startup script that initializes a stock
+        // Amazon Linux AMI, we don't have to worry about maintaining and keeping our AMI up to date. Amazon Linux applies
+        // important security updates on startup automatically.
+        // Tell the worker where to get its R5 JAR. This is a Conveyal S3 bucket with HTTP access turned on.
+        String workerDownloadUrl = String.format("https://r5-builds.s3.amazonaws.com/%s.jar", category.workerVersion);
+        ByteArrayOutputStream cfg = new ByteArrayOutputStream();
+
+        try {
+            workerConfig.store(cfg, "Worker config");
+            cfg.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            String workerConfigString = cfg.toString();
+            InputStream scriptIs = Broker.class.getClassLoader().getResourceAsStream("worker.sh");
+            ByteArrayOutputStream scriptBaos = new ByteArrayOutputStream();
+            ByteStreams.copy(scriptIs, scriptBaos);
+            scriptIs.close();
+            scriptBaos.close();
+            String scriptTemplate = scriptBaos.toString();
+            String logGroup = AnalysisServerConfig.workerLogGroup;
+            // Substitute values so that the worker can tag itself (see the bracketed numbers in R5 worker.sh).
+            // Tags are useful in the EC2 console and for billing.
+            String script = MessageFormat.format(scriptTemplate, workerDownloadUrl, logGroup, workerConfigString,
+                    group, user, category.graphId, category.workerVersion);
+            // Send the config to the new workers as EC2 "user data"
+            userDataScript = new String(Base64.getEncoder().encode(script.getBytes()));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    RequestSpotInstancesRequest prepareSpotRequest(){
+        LaunchSpecification launchSpecification = new LaunchSpecification()
+                .withImageId(AnalysisServerConfig.workerAmiId)
+                .withInstanceType(AnalysisServerConfig.workerInstanceType)
+                .withSubnetId(AnalysisServerConfig.workerSubnetId)
+                .withIamInstanceProfile(new IamInstanceProfileSpecification().withArn(AnalysisServerConfig.workerIamRole))
+                .withUserData(userDataScript)
+                .withEbsOptimized(true);
+
+        return new RequestSpotInstancesRequest()
+                .withLaunchSpecification(launchSpecification);
+    }
+
+    RunInstancesRequest prepareOnDemandRequest(){
+        // Set tags so we can identify the instances immediately in the EC2 console. The worker user data makes
+        // workers tag themselves, but with a lag.
+        TagSpecification instanceTags = new TagSpecification().withResourceType(ResourceType.Instance)
+                .withTags(
+                        new Tag("Name", "Analysis Worker"),
+                        new Tag("Project", "Analysis"),
+                        new Tag("networkId", category.graphId),
+                        new Tag("workerVersion", category.workerVersion),
+                        new Tag("group", group),
+                        new Tag("user", user)
+                );
+
+        return new RunInstancesRequest()
+            .withImageId(AnalysisServerConfig.workerAmiId)
+            .withInstanceType(AnalysisServerConfig.workerInstanceType)
+            .withSubnetId(AnalysisServerConfig.workerSubnetId)
+            .withIamInstanceProfile(new IamInstanceProfileSpecification().withArn(AnalysisServerConfig.workerIamRole))
+            .withInstanceInitiatedShutdownBehavior(ShutdownBehavior.Terminate)
+            .withTagSpecifications(instanceTags)
+            .withUserData(userDataScript)
+            .withEbsOptimized(true);
+    }
+}

--- a/src/main/java/com/conveyal/taui/analysis/broker/Job.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Job.java
@@ -41,6 +41,8 @@ public class Job {
 
     /* A unique identifier for this job, we use random UUIDs. */
     public final String jobId;
+    public final String accessGroup;
+    public final String createdBy;
 
     // This can be derived from other fields but is provided as a convenience.
     public final int nTasksTotal;
@@ -93,7 +95,7 @@ public class Job {
     // How many times we have started over delivering tasks, working through those that were not marked complete.
     public int deliveryPass = 0;
 
-    public Job (RegionalTask templateTask) {
+    public Job (RegionalTask templateTask, String accessGroup, String createdBy) {
         this.jobId = templateTask.jobId;
         this.templateTask = templateTask;
         this.nTasksTotal = templateTask.width * templateTask.height;
@@ -101,6 +103,8 @@ public class Job {
         this.workerCategory = new WorkerCategory(templateTask.graphId, templateTask.workerVersion);
         this.nTasksCompleted = 0;
         this.nextTaskToDeliver = 0;
+        this.createdBy = createdBy;
+        this.accessGroup = accessGroup;
     }
 
     public boolean markTaskCompleted(int taskId) {

--- a/src/main/java/com/conveyal/taui/analysis/broker/WorkerCatalog.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/WorkerCatalog.java
@@ -105,7 +105,7 @@ public class WorkerCatalog {
     }
 
     public synchronized int countWorkersInCategory(WorkerCategory workerCategory){
-        return (int) workerIdsByCategory.get(workerCategory).stream().count();
+        return workerIdsByCategory.get(workerCategory).size();
     }
 
     /**

--- a/src/main/java/com/conveyal/taui/analysis/broker/WorkerCatalog.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/WorkerCatalog.java
@@ -104,6 +104,10 @@ public class WorkerCatalog {
         return observationsByWorkerId.size();
     }
 
+    public synchronized int countOfWorkersInCategory(WorkerCategory workerCategory){
+        return (int) workerIdsByCategory.get(workerCategory).stream().count();
+    }
+
     /**
      * TODO should this return a protective copy? For now it's synchronized like all other methods.
      */

--- a/src/main/java/com/conveyal/taui/analysis/broker/WorkerCatalog.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/WorkerCatalog.java
@@ -104,7 +104,7 @@ public class WorkerCatalog {
         return observationsByWorkerId.size();
     }
 
-    public synchronized int countOfWorkersInCategory(WorkerCategory workerCategory){
+    public synchronized int countWorkersInCategory(WorkerCategory workerCategory){
         return (int) workerIdsByCategory.get(workerCategory).stream().count();
     }
 

--- a/src/main/java/com/conveyal/taui/controllers/BrokerController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BrokerController.java
@@ -134,8 +134,7 @@ public class BrokerController {
         String address = broker.getWorkerAddress(workerCategory);
         if (address == null) {
             // There are no workers that can handle this request. Request some.
-            // FIXME parts of the following method assume that it's synchronized
-            broker.createWorkersInCategory(workerCategory, accessGroup, userEmail);
+            broker.createOnDemandWorkerInCategory(workerCategory, accessGroup, userEmail);
             // No workers exist. Kick one off and return "service unavailable".
             response.header("Retry-After", "30");
             return jsonResponse(response, HttpStatus.ACCEPTED_202, "Starting routing server. Expect status updates within a few minutes.");

--- a/src/main/java/com/conveyal/taui/controllers/BrokerController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BrokerController.java
@@ -135,7 +135,11 @@ public class BrokerController {
         if (address == null) {
             // There are no workers that can handle this request. Request some.
             // FIXME parts of the following method assume that it's synchronized
-            broker.createWorkersInCategory(workerCategory, accessGroup, userEmail);
+            try {
+                broker.createWorkersInCategory(workerCategory, accessGroup, userEmail);
+            } catch (AnalysisServerException e){
+                throw e;
+            }
             // No workers exist. Kick one off and return "service unavailable".
             response.header("Retry-After", "30");
             return jsonResponse(response, HttpStatus.ACCEPTED_202, "Starting routing server. Expect status updates within a few minutes.");

--- a/src/main/java/com/conveyal/taui/controllers/BrokerController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BrokerController.java
@@ -135,11 +135,7 @@ public class BrokerController {
         if (address == null) {
             // There are no workers that can handle this request. Request some.
             // FIXME parts of the following method assume that it's synchronized
-            try {
-                broker.createWorkersInCategory(workerCategory, accessGroup, userEmail);
-            } catch (AnalysisServerException e){
-                throw e;
-            }
+            broker.createWorkersInCategory(workerCategory, accessGroup, userEmail);
             // No workers exist. Kick one off and return "service unavailable".
             response.header("Retry-After", "30");
             return jsonResponse(response, HttpStatus.ACCEPTED_202, "Starting routing server. Expect status updates within a few minutes.");


### PR DESCRIPTION
- Refactor to reduce EC2-specific code in Broker
- Launch method for both on-demand and spot instances (step toward #192)

Questions
- Refactor overloaded `createWorkersInCategory`?
- What should be synchronized (note FIXME in BrokerController)
- Is the try/catch block in BrokerController unnecessary?
- Should we just automatically add spot workers after the first few regional tasks are complete?