### PR TITLE
Increase target tasks and cap on workers

### DIFF
--- a/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
@@ -73,7 +73,7 @@ public class Broker {
     public final int AUTO_START_SPOT_INSTANCES_AT_TASK  = MAX_TASKS_PER_WORKER * 2 + 10; //42
 
     /** The maximum number of spot instances allowable in an automatic request */
-    public final int MAX_WORKERS_PER_CATEGORY = 100;
+    public final int MAX_WORKERS_PER_CATEGORY = 250;
 
     /**
      * How long to give workers to start up (in ms) before assuming that they have started (and starting more

--- a/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Broker.java
@@ -66,7 +66,7 @@ public class Broker {
 
     /** Used when auto-starting spot instances. Set to a smaller value to increase the number of workers requested
      * automatically*/
-    public final int TARGET_TASKS_PER_WORKER = 400;
+    public final int TARGET_TASKS_PER_WORKER = 800;
 
     /** We want to request spot instances to "boost" regional analyses after a few regional task results are received
      * for a given workerCategory. Do so after receiving results for an arbitrary task toward the beginning of the job*/


### PR DESCRIPTION
We've seen stable auto-scaling behavior on production for a couple months now.  It seems like a good time to increase this parameter, allowing large regional analyses to complete more quickly.