### PR TITLE
Add CORS response headers

### DIFF
--- a/src/main/java/com/conveyal/taui/AnalysisServer.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServer.java
@@ -79,7 +79,8 @@ public class AnalysisServer {
             res.header("Access-Control-Allow-Origin", "*");
 
             // End early if options request
-            if (HttpMethod.options.toString().equals(req.requestMethod())) return;
+            String method = req.requestMethod();
+            if ("OPTIONS".equals(method)) return;
 
             // Default is JSON, will be overridden by the few controllers that do not return JSON
             res.type("application/json");


### PR DESCRIPTION
This is necessary for the new way the front end is deployed. The front end and back end are no longer distributed from the same server so the "Origin" is different, requiring the API requests to be "Cross-Origin-Resource-Sharing" requests.

I was attempting to get around it by proxying requests through a node server deployed the same way as the front end. But it turns out the new service has a size limit on requests (reasonable) and recommends large files uploads to be done through signed URLS. 

With the upcoming changes planned for resources I plan to make changes that would use that style (large file uploads going directly to S3).