### PR TITLE
New AWS Java SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,13 @@
             <version>1.11.341</version>
         </dependency>
 
+        <!-- New AWS SDK for interacting with EC2 -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
+            <version>2.6.3</version>
+        </dependency>
+
         <!-- Rest Assured is an assertion library that makes testing web APIs easy. -->
         <dependency>
             <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
To allow use of EC2 R5Xlarge and R5Large instances