### PR TITLE
Migrate EC2 Launcher to AWS SDK v2.x

### DIFF
--- a/analysis.properties.test
+++ b/analysis.properties.test
@@ -70,9 +70,7 @@ max-workers=8
 worker-iam-role=test-test
 
 # Type of EC2 instance to start up, in AWS Java SDK enum format (first letter and letter after period capitalized).
-# e.g. R3Xlarge which has 16gb of memory and is not too costly. Additional CPU power doesn't buy us much.
-# TODO The version of the AWS SDK we currently use in R5 does not support r4.* instances, we should upgrade.
-worker-type=R3Xlarge
+worker-type=r5.xlarge
 
 # The AWS Cloudwatch log group for worker EC2 instances.
 # Each worker creates its own log stream within this log group at startup.

--- a/analysis.properties.test
+++ b/analysis.properties.test
@@ -69,7 +69,8 @@ max-workers=8
 # This is the IAM role whose policy is defined in iam.yml (and is recursively referenced therein).
 worker-iam-role=test-test
 
-# Type of EC2 instance to start up, in AWS Java SDK enum format (first letter and letter after period capitalized).
+# Type of EC2 instance to start up, in the standard AWS format containing a dot as listed on
+# https://aws.amazon.com/ec2/instance-types/
 worker-type=r5.xlarge
 
 # The AWS Cloudwatch log group for worker EC2 instances.

--- a/analysis.properties.tmp
+++ b/analysis.properties.tmp
@@ -68,9 +68,9 @@ max-workers=8
 # This is the IAM role whose policy is defined in iam.yml (and is recursively referenced therein).
 worker-iam-role=arn:aws:iam::abcdef123456
 
-# Type of EC2 instance to start up, in AWS Java SDK enum format (first letter and letter after period capitalized).
-# e.g. R3Xlarge which has 16gb of memory and is not too costly. Additional CPU power doesn't buy us much.
-worker-type=R4Xlarge
+# Type of EC2 instance to start up, in the standard AWS format containing a dot as listed on
+# https://aws.amazon.com/ec2/instance-types/
+worker-type=r5.xlarge
 
 # The AWS Cloudwatch log group for worker EC2 instances.
 # Each worker creates its own log stream within this log group at startup.

--- a/pom.xml
+++ b/pom.xml
@@ -206,11 +206,10 @@
             <version>4.5.3</version>
         </dependency>
 
-        <!-- AWS SDK for interacting with EC2 -->
+        <!-- AWS SDK for interacting with EC2. Version numbers are provided by Bill of Materials imported below. -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-ec2</artifactId>
-            <version>1.11.341</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
         </dependency>
 
         <!-- Rest Assured is an assertion library that makes testing web APIs easy. -->
@@ -243,4 +242,18 @@
             <version>e6a78d3af9d67f6f6240261fcba497d3b50f9399</version>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import AWS SDK Bill of Materials in case different modules should be at different version numbers. -->
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.6.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/src/main/java/com/conveyal/taui/AnalysisServer.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServer.java
@@ -177,9 +177,8 @@ public class AnalysisServer {
             // and change the listening ports. TODO port is hardwired here and also in SinglePointAnalysisController
             LocalCluster.start(feedSourceCache, OSMPersistence.cache, 1);
         } else {
-            ApiMain.initialize(AnalysisServerConfig.awsRegion, AnalysisServerConfig.bundleBucket,
-                    null, AnalysisServerConfig
-                    .localCacheDirectory);
+            ApiMain.initialize(AnalysisServerConfig.awsRegion, AnalysisServerConfig.bundleBucket, null,
+                    AnalysisServerConfig.localCacheDirectory);
         }
 
         LOG.info("Conveyal Analysis server is ready.");

--- a/src/main/java/com/conveyal/taui/AnalysisServerConfig.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServerConfig.java
@@ -1,9 +1,9 @@
 package com.conveyal.taui;
 
-import com.amazonaws.services.ec2.model.InstanceType;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
 
 import java.io.FileInputStream;
 import java.util.HashSet;

--- a/src/main/java/com/conveyal/taui/AnalysisServerConfig.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServerConfig.java
@@ -83,6 +83,9 @@ public abstract class AnalysisServerConfig {
         if (!offline && (bundleBucket == null || auth0ClientId == null || auth0Secret == null || gridBucket == null || resultsBucket == null || workerLogGroup == null)) {
             LOG.error("Application is missing config variables needed in online mode.");
         }
+        if (workerInstanceType == InstanceType.UNKNOWN_TO_SDK_VERSION) {
+            LOG.error("The EC2 instance type specified in the configuration was not recognized. You will not be able to start EC2 workers.");
+        }
         if (!missingKeys.isEmpty()) {
             LOG.error("You must provide these configuration properties: {}", String.join(", ", missingKeys));
             System.exit(1);

--- a/src/main/java/com/conveyal/taui/AnalysisServerConfig.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServerConfig.java
@@ -62,7 +62,7 @@ public abstract class AnalysisServerConfig {
     public static final String workerAmiId = getProperty("worker-ami-id", true);
     public static final String workerSubnetId = getProperty("worker-subnet-id", true);
     public static final String workerIamRole = getProperty("worker-iam-role", true);
-    public static final InstanceType workerInstanceType = InstanceType.valueOf(getProperty("worker-type", true));
+    public static final InstanceType workerInstanceType = InstanceType.fromValue(getProperty("worker-type", true));
 
     // For use in testing - setting this field will activate alternate code paths that cause intentional failures.
     public static boolean testTaskRedelivery = false;

--- a/src/main/java/com/conveyal/taui/analysis/broker/EC2Launcher.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/EC2Launcher.java
@@ -1,13 +1,4 @@
 package com.conveyal.taui.analysis.broker;
-
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
-import com.amazonaws.services.ec2.model.RequestSpotInstancesRequest;
-import com.amazonaws.services.ec2.model.RequestSpotInstancesResult;
-import com.amazonaws.services.ec2.model.RunInstancesRequest;
-import com.amazonaws.services.ec2.model.RunInstancesResult;
 import com.conveyal.taui.AnalysisServerConfig;
 import com.conveyal.taui.ExecutorServices;
 
@@ -15,6 +6,12 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.RequestSpotInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.RequestSpotInstancesResponse;
+import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.RunInstancesResponse;
 
 /**
  * AWS SDK client to launch EC2 fleets.  Should be initialized once (in Broker)
@@ -24,24 +21,17 @@ public class EC2Launcher {
     private static final Logger LOG = LoggerFactory.getLogger(EC2Launcher.class);
 
     /** Amazon AWS SDK client. */
-    private AmazonEC2 ec2;
+    private Ec2Client ec2;
 
-    EC2Launcher(){
-
-        AmazonEC2ClientBuilder ec2Builder = AmazonEC2ClientBuilder.standard();
-
+    EC2Launcher() {
         // When running on an EC2 instance, default to the AWS region of that instance
-        Region region = null;
-        if (!AnalysisServerConfig.offline) {
-            region = Regions.getCurrentRegion();
-        }
-        if (region != null) {
-            ec2Builder.setRegion(region.getName());
+        // "If you don't explicitly set a region using the region method, the SDK consults the default region provider
+        // chain to try and determine the region to use."
+        if (AnalysisServerConfig.offline) {
+            ec2 = Ec2Client.builder().region(Region.of(AnalysisServerConfig.awsRegion)).build();
         } else {
-            ec2Builder.withRegion(AnalysisServerConfig.awsRegion);
+            ec2 = Ec2Client.create();
         }
-        ec2 = ec2Builder.build();
-
     }
 
     public void launch (EC2RequestConfiguration requestConfig, int nOnDemand, int nSpot) {
@@ -52,13 +42,10 @@ public class EC2Launcher {
 
             String clientToken = UUID.randomUUID().toString().replaceAll("-", "");
 
-            RunInstancesRequest onDemandRequest = requestConfig.prepareOnDemandRequest()
-                    .withMinCount(1)
-                    .withMaxCount(nOnDemand)
-                    .withClientToken(clientToken);
+            RunInstancesRequest onDemandRequest = requestConfig.prepareOnDemandRequest(1, nOnDemand, clientToken);
 
             ExecutorServices.light.execute(() -> {
-                RunInstancesResult res = ec2.runInstances(onDemandRequest);
+                RunInstancesResponse response = ec2.runInstances(onDemandRequest);
                 // TODO check and log result of request.
             });
         }
@@ -69,12 +56,10 @@ public class EC2Launcher {
 
             String clientToken = UUID.randomUUID().toString().replaceAll("-", "");
 
-            RequestSpotInstancesRequest spotRequest = requestConfig.prepareSpotRequest()
-                    .withInstanceCount(nSpot)
-                    .withClientToken(clientToken);
+            RequestSpotInstancesRequest spotRequest = requestConfig.prepareSpotRequest(nSpot, clientToken);
 
             ExecutorServices.light.execute(() -> {
-                RequestSpotInstancesResult res = ec2.requestSpotInstances(spotRequest);
+                RequestSpotInstancesResponse response = ec2.requestSpotInstances(spotRequest);
                 // TODO check and log result of request.
             });
         }

--- a/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
@@ -23,28 +23,22 @@ import java.util.stream.Collectors;
 public class EC2RequestConfiguration {
 
     private final WorkerCategory category;
-    private final String group;
-    private final String user;
-    private final String projectId;
-    private final String regionId;
+    private final WorkerTags workerTags;
     private final String userDataScript;
     private final TagSpecification instanceTags;
-    private Properties workerConfig; // FIXME this can't be made final because it's only initialized when offline=false
+    private Properties workerConfig;
 
     @Override
     public String toString() {
-        return String.format("%s for %s (%s)", category, user, group);
+        return String.format("%s for %s (%s)", category, workerTags.user, workerTags.group);
     }
 
     // The final four parameters should serve only as tags to identify how the worker started up.
     // Note that a worker could migrate to a new project after finishing a job on a different project.
     // The region ID is redundant (implied by the category.bundleId) but useful for categorizing costs in EC2.
-    EC2RequestConfiguration(WorkerCategory category, String group, String user, String projectId, String regionId) {
+    EC2RequestConfiguration(WorkerCategory category, WorkerTags workerTags) {
         this.category = category;
-        this.group = group;
-        this.user = user;
-        this.projectId = projectId;
-        this.regionId = regionId;
+        this.workerTags = workerTags;
 
         if (!AnalysisServerConfig.offline) {
             workerConfig = new Properties();
@@ -84,10 +78,10 @@ public class EC2RequestConfiguration {
                 Tag.builder().key("Name").value("AnalysisWorker").build(),
                 Tag.builder().key("networkId").value(category.graphId).build(),
                 Tag.builder().key("workerVersion").value(category.workerVersion).build(),
-                Tag.builder().key("group").value(group).build(),
-                Tag.builder().key("user").value(user).build(),
-                Tag.builder().key("project").value(projectId).build(),
-                Tag.builder().key("region").value(regionId).build()
+                Tag.builder().key("group").value(workerTags.group).build(),
+                Tag.builder().key("user").value(workerTags.user).build(),
+                Tag.builder().key("project").value(workerTags.projectId).build(),
+                Tag.builder().key("region").value(workerTags.regionId).build()
         ).build();
 
         // Convert the above tags to a command line parameter for the AWS CLI, to allow spot instances to tag themselves.

--- a/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/EC2RequestConfiguration.java
@@ -18,23 +18,33 @@ import java.io.InputStream;
 import java.text.MessageFormat;
 import java.util.Base64;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public class EC2RequestConfiguration {
-    private WorkerCategory category;
-    private String group;
-    private String user;
-    private String userDataScript;
-    private Properties workerConfig;
+
+    private final WorkerCategory category;
+    private final String group;
+    private final String user;
+    private final String projectId;
+    private final String regionId;
+    private final String userDataScript;
+    private final TagSpecification instanceTags;
+    private Properties workerConfig; // FIXME this can't be made final because it's only initialized when offline=false
 
     @Override
     public String toString() {
         return String.format("%s for %s (%s)", category, user, group);
     }
 
-    EC2RequestConfiguration(WorkerCategory category, String group, String user) {
+    // The final four parameters should serve only as tags to identify how the worker started up.
+    // Note that a worker could migrate to a new project after finishing a job on a different project.
+    // The region ID is redundant (implied by the category.bundleId) but useful for categorizing costs in EC2.
+    EC2RequestConfiguration(WorkerCategory category, String group, String user, String projectId, String regionId) {
         this.category = category;
         this.group = group;
         this.user = user;
+        this.projectId = projectId;
+        this.regionId = regionId;
 
         if (!AnalysisServerConfig.offline) {
             workerConfig = new Properties();
@@ -68,6 +78,26 @@ public class EC2RequestConfiguration {
             throw new RuntimeException(e);
         }
 
+        // Set tags so we can identify the instances immediately in the EC2 console. The worker user data makes
+        // workers tag themselves, but with a lag.
+        instanceTags = TagSpecification.builder().resourceType(ResourceType.INSTANCE).tags(
+                Tag.builder().key("Name").value("AnalysisWorker").build(),
+                Tag.builder().key("networkId").value(category.graphId).build(),
+                Tag.builder().key("workerVersion").value(category.workerVersion).build(),
+                Tag.builder().key("group").value(group).build(),
+                Tag.builder().key("user").value(user).build(),
+                Tag.builder().key("project").value(projectId).build(),
+                Tag.builder().key("region").value(regionId).build()
+        ).build();
+
+        // Convert the above tags to a command line parameter for the AWS CLI, to allow spot instances to tag themselves.
+        // This ensures we use exactly the same set of tags, set in the same way, for both spot and on-demand instances.
+        // Note the tagging part of the script will be run even on instances already tagged when created. This is
+        // redundant but simpler to maintain and should be harmless.
+        String tagString = instanceTags.tags().stream()
+                .map(tag -> String.format("Key=%s,Value=%s", tag.key(), tag.value()))
+                .collect(Collectors.joining(" "));
+
         try {
             String workerConfigString = cfg.toString();
             InputStream scriptIs = Broker.class.getClassLoader().getResourceAsStream("worker.sh");
@@ -79,8 +109,7 @@ public class EC2RequestConfiguration {
             String logGroup = AnalysisServerConfig.workerLogGroup;
             // Substitute values so that the worker can tag itself (see the bracketed numbers in worker.sh).
             // Tags are useful in the EC2 console and for billing.
-            String script = MessageFormat.format(scriptTemplate, workerDownloadUrl, logGroup, workerConfigString,
-                    group, user, category.graphId, category.workerVersion);
+            String script = MessageFormat.format(scriptTemplate, workerDownloadUrl, logGroup, workerConfigString, tagString);
             // Send the config to the new workers as EC2 "user data"
             userDataScript = new String(Base64.getEncoder().encode(script.getBytes()));
         } catch (IOException e) {
@@ -106,17 +135,6 @@ public class EC2RequestConfiguration {
     }
 
     RunInstancesRequest prepareOnDemandRequest (int minInstances, int maxInstances, String clientToken) {
-        // Set tags so we can identify the instances immediately in the EC2 console. The worker user data makes
-        // workers tag themselves, but with a lag.
-        TagSpecification instanceTags = TagSpecification.builder().resourceType(ResourceType.INSTANCE).tags(
-            Tag.builder().key("Name").value("Analysis Worker").build(),
-            Tag.builder().key("Project").value("Analysis").build(),
-            Tag.builder().key("networkId").value(category.graphId).build(),
-            Tag.builder().key("workerVersion").value(category.workerVersion).build(),
-            Tag.builder().key("group").value(group).build(),
-            Tag.builder().key("user").value(user).build()
-        ).build();
-
         return RunInstancesRequest.builder()
             .imageId(AnalysisServerConfig.workerAmiId)
             .instanceType(AnalysisServerConfig.workerInstanceType)

--- a/src/main/java/com/conveyal/taui/analysis/broker/Job.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Job.java
@@ -42,13 +42,8 @@ public class Job {
     /* A unique identifier for this job, we use random UUIDs. */
     public final String jobId;
 
-    // Tags for starting worker
-    // FIXME these fields should be grouped together a new type WorkerInstanceTags. They are being stored and passed around a lot.
-    // This type should explain these are strings purely for categorization of workers and should not be used for other purposes.
-    public final String accessGroup;
-    public final String createdBy;
-    public final String projectId;
-    public final String regionId;
+    /** Tags to be added to the worker instance to assist in usage analysis and cost breakdowns. */
+    public final WorkerTags workerTags;
 
     // This can be derived from other fields but is provided as a convenience.
     public final int nTasksTotal;
@@ -101,7 +96,7 @@ public class Job {
     // How many times we have started over delivering tasks, working through those that were not marked complete.
     public int deliveryPass = 0;
 
-    public Job (RegionalTask templateTask, String accessGroup, String createdBy, String projectId, String regionId) {
+    public Job (RegionalTask templateTask, WorkerTags workerTags) {
         this.jobId = templateTask.jobId;
         this.templateTask = templateTask;
         this.nTasksTotal = templateTask.width * templateTask.height;
@@ -109,10 +104,7 @@ public class Job {
         this.workerCategory = new WorkerCategory(templateTask.graphId, templateTask.workerVersion);
         this.nTasksCompleted = 0;
         this.nextTaskToDeliver = 0;
-        this.createdBy = createdBy;
-        this.accessGroup = accessGroup;
-        this.projectId = projectId;
-        this.regionId = regionId;
+        this.workerTags = workerTags;
     }
 
     public boolean markTaskCompleted(int taskId) {

--- a/src/main/java/com/conveyal/taui/analysis/broker/Job.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/Job.java
@@ -41,8 +41,14 @@ public class Job {
 
     /* A unique identifier for this job, we use random UUIDs. */
     public final String jobId;
+
+    // Tags for starting worker
+    // FIXME these fields should be grouped together a new type WorkerInstanceTags. They are being stored and passed around a lot.
+    // This type should explain these are strings purely for categorization of workers and should not be used for other purposes.
     public final String accessGroup;
     public final String createdBy;
+    public final String projectId;
+    public final String regionId;
 
     // This can be derived from other fields but is provided as a convenience.
     public final int nTasksTotal;
@@ -95,7 +101,7 @@ public class Job {
     // How many times we have started over delivering tasks, working through those that were not marked complete.
     public int deliveryPass = 0;
 
-    public Job (RegionalTask templateTask, String accessGroup, String createdBy) {
+    public Job (RegionalTask templateTask, String accessGroup, String createdBy, String projectId, String regionId) {
         this.jobId = templateTask.jobId;
         this.templateTask = templateTask;
         this.nTasksTotal = templateTask.width * templateTask.height;
@@ -105,6 +111,8 @@ public class Job {
         this.nextTaskToDeliver = 0;
         this.createdBy = createdBy;
         this.accessGroup = accessGroup;
+        this.projectId = projectId;
+        this.regionId = regionId;
     }
 
     public boolean markTaskCompleted(int taskId) {

--- a/src/main/java/com/conveyal/taui/analysis/broker/RedeliveryTest.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/RedeliveryTest.java
@@ -62,7 +62,7 @@ public class RedeliveryTest {
         templateTask.height = 1;
         templateTask.width = N_TASKS_PER_JOB;
         templateTask.scenarioId = "FAKE";
-        RegionalAnalysisController.broker.enqueueTasksForRegionalJob(templateTask,"test", "test");
+        RegionalAnalysisController.broker.enqueueTasksForRegionalJob(templateTask,"test", "test", "projectId", "regionId");
     }
 
     public static String compactUUID() {

--- a/src/main/java/com/conveyal/taui/analysis/broker/RedeliveryTest.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/RedeliveryTest.java
@@ -62,7 +62,8 @@ public class RedeliveryTest {
         templateTask.height = 1;
         templateTask.width = N_TASKS_PER_JOB;
         templateTask.scenarioId = "FAKE";
-        RegionalAnalysisController.broker.enqueueTasksForRegionalJob(templateTask,"test", "test", "projectId", "regionId");
+        WorkerTags workerTags = new WorkerTags("testGroup", "testUser", "projectId", "regionId");
+        RegionalAnalysisController.broker.enqueueTasksForRegionalJob(templateTask, workerTags);
     }
 
     public static String compactUUID() {

--- a/src/main/java/com/conveyal/taui/analysis/broker/WorkerTags.java
+++ b/src/main/java/com/conveyal/taui/analysis/broker/WorkerTags.java
@@ -1,0 +1,40 @@
+package com.conveyal.taui.analysis.broker;
+
+import com.conveyal.taui.models.RegionalAnalysis;
+
+/**
+ * An immutable group of tags to be added to the worker instance to assist in usage analysis and cost breakdowns.
+ * These Strings are purely for categorization of workers and should not be used for other purposes, only passed through
+ * to the AWS SDK.
+ */
+public class WorkerTags {
+
+    /** The unique name of the permissions group under which the user is working. */
+    public final String group;
+
+    /** A unique ID for the user (the user's email address). */
+    public final String user;
+
+    /** The UUID for the project. */
+    public final String projectId;
+
+    /** The UUID for the project. */
+    public final String regionId;
+
+    public WorkerTags (String group, String user, String projectId, String regionId) {
+        this.group = group;
+        this.user = user;
+        this.projectId = projectId;
+        this.regionId = regionId;
+    }
+
+    public static WorkerTags fromRegionalAnalysis (RegionalAnalysis regionalAnalysis) {
+        return new WorkerTags(
+                regionalAnalysis.accessGroup,
+                regionalAnalysis.createdBy,
+                regionalAnalysis.projectId,
+                regionalAnalysis.regionId
+        );
+    }
+
+}

--- a/src/main/java/com/conveyal/taui/controllers/BrokerController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BrokerController.java
@@ -13,6 +13,7 @@ import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.analysis.broker.Broker;
 import com.conveyal.taui.analysis.broker.JobStatus;
 import com.conveyal.taui.analysis.broker.WorkerObservation;
+import com.conveyal.taui.analysis.broker.WorkerTags;
 import com.conveyal.taui.models.AnalysisRequest;
 import com.conveyal.taui.models.Bundle;
 import com.conveyal.taui.models.Project;
@@ -139,7 +140,8 @@ public class BrokerController {
         String address = broker.getWorkerAddress(workerCategory);
         if (address == null) {
             // There are no workers that can handle this request. Request some.
-            broker.createOnDemandWorkerInCategory(workerCategory, accessGroup, userEmail, project._id, project.regionId);
+            WorkerTags workerTags = new WorkerTags(accessGroup, userEmail, project._id, project.regionId);
+            broker.createOnDemandWorkerInCategory(workerCategory, workerTags);
             // No workers exist. Kick one off and return "service unavailable".
             response.header("Retry-After", "30");
             return jsonResponse(response, HttpStatus.ACCEPTED_202, "Starting routing server. Expect status updates within a few minutes.");

--- a/src/main/java/com/conveyal/taui/controllers/BrokerController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BrokerController.java
@@ -139,7 +139,7 @@ public class BrokerController {
         String address = broker.getWorkerAddress(workerCategory);
         if (address == null) {
             // There are no workers that can handle this request. Request some.
-            broker.createOnDemandWorkerInCategory(workerCategory, accessGroup, userEmail);
+            broker.createOnDemandWorkerInCategory(workerCategory, accessGroup, userEmail, project._id, project.regionId);
             // No workers exist. Kick one off and return "service unavailable".
             response.header("Retry-After", "30");
             return jsonResponse(response, HttpStatus.ACCEPTED_202, "Starting routing server. Expect status updates within a few minutes.");

--- a/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
@@ -307,7 +307,7 @@ public class RegionalAnalysisController {
         templateTask.grid = opportunityDataset.getKey(GridExporter.Format.GRID);
 
         // Register the regional job with the broker, which will distribute individual tasks to workers and track progress.
-        broker.enqueueTasksForRegionalJob(templateTask, regionalAnalysis.accessGroup, regionalAnalysis.createdBy);
+        broker.enqueueTasksForRegionalJob(templateTask, regionalAnalysis.accessGroup, regionalAnalysis.createdBy, regionalAnalysis.projectId, regionalAnalysis.regionId);
 
         return regionalAnalysis;
     }

--- a/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/taui/controllers/RegionalAnalysisController.java
@@ -10,6 +10,7 @@ import com.conveyal.taui.AnalysisServerConfig;
 import com.conveyal.taui.AnalysisServerException;
 import com.conveyal.taui.SelectingGridReducer;
 import com.conveyal.taui.analysis.broker.Broker;
+import com.conveyal.taui.analysis.broker.WorkerTags;
 import com.conveyal.taui.grids.GridExporter;
 import com.conveyal.taui.models.AnalysisRequest;
 import com.conveyal.taui.models.OpportunityDataset;
@@ -307,7 +308,7 @@ public class RegionalAnalysisController {
         templateTask.grid = opportunityDataset.getKey(GridExporter.Format.GRID);
 
         // Register the regional job with the broker, which will distribute individual tasks to workers and track progress.
-        broker.enqueueTasksForRegionalJob(templateTask, regionalAnalysis.accessGroup, regionalAnalysis.createdBy, regionalAnalysis.projectId, regionalAnalysis.regionId);
+        broker.enqueueTasksForRegionalJob(templateTask, WorkerTags.fromRegionalAnalysis(regionalAnalysis));
 
         return regionalAnalysis;
     }

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -6,10 +6,7 @@
 # 0: the URL to grab the worker JAR from
 # 1: the AWS log group to use
 # 2: the worker configuration to use
-# 3: the (Auth0) accessGroup (useful for billing)
-# 4: the (Auth0) user who made the request that started the worker
-# 5: the UUID of the TransportNetwork the worker will start analyzing
-# 6: the worker version to use
+# 3: a string containing all tags to set on the worker in the format "Key=K0,Value=V0 Key=K1,Value=V1"
 # If you are reading this comment inside the EC2 user data field, this variable substitution has already happened.
 # Shell variable references that contain brackets are single-quoted to tell MessageFormat not to substitute them, and
 # are substituted by EC2 on startup. Be very careful not to put any stray single quotes in this file, even in comments!
@@ -104,12 +101,11 @@ while :
 do
     # Attempt to tag, with jitter to avoid exceeding (presumed) AWS rate limits
     sleep $[$RANDOM % 8 + 15]s
-    sudo -u ec2-user aws ec2 create-tags --resources $INSTANCE --tags Key=Name,Value=AnalysisWorker \
-    Key=Project,Value=Analysis Key=group,Value={3} Key=user,Value={4} Key=networkId,Value={5} Key=workerVersion,Value={6} \
+    sudo -u ec2-user aws ec2 create-tags --resources $INSTANCE --tags {3} \
     >> $LOGFILE 2>&1
     if [ $? -eq 0 ] # bash exit status 0 = success
     then
-        echo Instance $INSTANCE successfully tagged itself with group {3}. >> $LOGFILE
+        echo Instance $INSTANCE successfully tagged itself with {3}. >> $LOGFILE
         break
     fi
 done


### PR DESCRIPTION
Older versions of the AWS SDK don't have the `R5XLarge` enum value for the instance type we're now using. We could bump to `1.11.584` to keep the old programming API but might as well start migrating to the 2.x SDK. The main difference for our purposes is that it uses builders to create immutable instances.