### PR TITLE
Fix CORS requests for Safari/Firefox

### DIFF
--- a/src/main/java/com/conveyal/taui/AnalysisServer.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServer.java
@@ -98,7 +98,7 @@ public class AnalysisServer {
         // Handle CORS Options requests.
         options("/*", (req, res) -> {
             res.header("Access-Control-Allow-Headers", "Authorization, Origin");
-            res.header("Access-Control-Allow-Methods", "GET, OPTIONS, POST, PUT");
+            res.header("Access-Control-Allow-Methods", "DELETE, GET, OPTIONS, POST, PUT");
             return "OK";
         });
 

--- a/src/main/java/com/conveyal/taui/AnalysisServer.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServer.java
@@ -97,8 +97,8 @@ public class AnalysisServer {
 
         // Handle CORS Options requests.
         options("/*", (req, res) -> {
-            res.header("Access-Control-Allow-Headers", "*");
-            res.header("Access-Control-Allow-Methods", "*");
+            res.header("Access-Control-Allow-Headers", "Authorization, Origin");
+            res.header("Access-Control-Allow-Methods", "GET, OPTIONS, POST, PUT");
             return "OK";
         });
 


### PR DESCRIPTION
Switch from allowing * headers to an explicit list to fix CORS for Safari/Firefox