### PR TITLE
Add Content-Type and Accept CORS headers for analysis requests

### DIFF
--- a/src/main/java/com/conveyal/taui/AnalysisServer.java
+++ b/src/main/java/com/conveyal/taui/AnalysisServer.java
@@ -97,7 +97,7 @@ public class AnalysisServer {
 
         // Handle CORS Options requests.
         options("/*", (req, res) -> {
-            res.header("Access-Control-Allow-Headers", "Authorization, Origin");
+            res.header("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Origin");
             res.header("Access-Control-Allow-Methods", "DELETE, GET, OPTIONS, POST, PUT");
             return "OK";
         });


### PR DESCRIPTION
Content-Type and Accept are required headers for specific requests from the UI, including GeoTIFF creation. 