### PR TITLE
Don't signal retry for requests that timed out

### DIFF
--- a/src/main/java/com/conveyal/taui/controllers/BrokerController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BrokerController.java
@@ -178,10 +178,10 @@ public class BrokerController {
             LOG.info("Timeout waiting for response from worker.");
             // Aborting the request might help release resources - we had problems with exhausting connection pools here.
             httpPost.abort();
-            return jsonResponse(response, HttpStatus.SERVICE_UNAVAILABLE_503, "Routing server timed out. For the " +
-                    "complexity of this scenario, your request may have too long a duration from start time to end " +
-                    "time, or too many simulated schedules. If you are using Routing Engine version < 4.5.1, your " +
-                    "scenario may still be in preparation; try again in a few minutes.");
+            return jsonResponse(response, HttpStatus.BAD_REQUEST_400, "Routing server timed out. For the " +
+                    "complexity of this scenario, your request may have too many simulated schedules. If you are " +
+                    "using Routing Engine version < 4.5.1, your scenario may still be in preparation and you should " +
+                    "try again in a few minutes.");
         } catch (NoRouteToHostException nrthe){
             LOG.info("Worker in category {} was previously cataloged but is not reachable now. This is expected if a " +
                     "user made a single-point request within WORKER_RECORD_DURATION_MSEC after shutdown.", workerCategory);

--- a/src/main/java/com/conveyal/taui/controllers/BrokerController.java
+++ b/src/main/java/com/conveyal/taui/controllers/BrokerController.java
@@ -175,10 +175,13 @@ public class BrokerController {
             // probably degrades the perceived responsiveness of single-point requests.
             return ByteStreams.toByteArray(entity.getContent());
         } catch (SocketTimeoutException ste) {
-            LOG.info("Timeout waiting for response from worker. Perhaps an old version of R5 has blocked while preparing a network.");
+            LOG.info("Timeout waiting for response from worker.");
             // Aborting the request might help release resources - we had problems with exhausting connection pools here.
             httpPost.abort();
-            return jsonResponse(response, HttpStatus.ACCEPTED_202, "Preparing network for analysis");
+            return jsonResponse(response, HttpStatus.SERVICE_UNAVAILABLE_503, "Routing server timed out. For the " +
+                    "complexity of this scenario, your request may have too long a duration from start time to end " +
+                    "time, or too many simulated schedules. If you are using Routing Engine version < 4.5.1, your " +
+                    "scenario may still be in preparation; try again in a few minutes.");
         } catch (NoRouteToHostException nrthe){
             LOG.info("Worker in category {} was previously cataloged but is not reachable now. This is expected if a " +
                     "user made a single-point request within WORKER_RECORD_DURATION_MSEC after shutdown.", workerCategory);

--- a/src/main/java/com/conveyal/taui/util/HttpStatus.java
+++ b/src/main/java/com/conveyal/taui/util/HttpStatus.java
@@ -10,5 +10,5 @@ public class HttpStatus {
     public static final int NO_CONTENT_204 = 204;
     public static final int BAD_REQUEST_400 = 400;
     public static final int SERVER_ERROR_500 = 500;
-    public static final int SERVICE_UNAVAILABLE_503 = 503;
+    public static final int SERVICE_UNAVAILABLE = 000;
 }

--- a/src/main/java/com/conveyal/taui/util/HttpStatus.java
+++ b/src/main/java/com/conveyal/taui/util/HttpStatus.java
@@ -10,5 +10,5 @@ public class HttpStatus {
     public static final int NO_CONTENT_204 = 204;
     public static final int BAD_REQUEST_400 = 400;
     public static final int SERVER_ERROR_500 = 500;
-    public static final int SERVICE_UNAVAILABLE = 000;
+    public static final int SERVICE_UNAVAILABLE_503 = 503;
 }


### PR DESCRIPTION
As discussed in #222, analyses that take longer than the timeout will start piling up because the front-end keeps retrying. The changes in this PR warn that the requested analysis was too complex, rather than signalling the front-end to retry.

To test, run an analysis that exceeds the timeout (e.g. a large number of simulated schedules with bike egress on a complex network) and see if the expected warning is displayed in the front-end.