### PR TITLE
fix AggregationAreaController (convert to WGS84)

### DIFF
--- a/src/main/java/com/conveyal/taui/controllers/AggregationAreaController.java
+++ b/src/main/java/com/conveyal/taui/controllers/AggregationAreaController.java
@@ -99,7 +99,9 @@ public class AggregationAreaController {
 
         ShapefileReader reader = new ShapefileReader(shpFile);
 
-        List<Geometry> geometries = reader.stream().map(f -> (Geometry) f.getDefaultGeometry()).collect(Collectors.toList());
+        List<Geometry> geometries = reader.wgs84Stream()
+                    .map(f -> (Geometry) f.getDefaultGeometry())
+                    .collect(Collectors.toList());
         UnaryUnionOp union = new UnaryUnionOp(geometries);
         Geometry merged = union.union();
 


### PR DESCRIPTION
Previously it was streaming the raw, possibly projected geometries
without even checking whether they were in WGS84 or not. It did not
complain that they were not in WGS84, just said they were too big (since
the units were meters or feet instead of degrees as expected).

This is one small part of #213 which we are applying as a bugfix.