### PR TITLE
Remove code coverage report generation and uploads from CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,9 @@ script:
 before_cache: rm -rf $HOME/.m2/repository/com/conveyal
 
 after_success:
-  # Upload coverage results to codecov
-  - bash <(curl -s https://codecov.io/bash)
   # Upload a shaded jar to S3
-  - pip install --user awscli && export PATH=$PATH:~/.local/bin/
-  # TODO once we have tags use git describe
+  - if [[ "$TRAVIS_SECURE_ENV_VARS" = true ]]; then pip install --user awscli && export PATH=$PATH:~/.local/bin/; fi
   - if [[ "$TRAVIS_SECURE_ENV_VARS" = true ]]; then aws s3 cp --acl public-read target/analysis.jar s3://analyst-builds/analysis-${TRAVIS_BRANCH}-`git rev-parse --short HEAD`.jar; fi
-  - if [[ "$TRAVIS_SECURE_ENV_VARS" = true ]] && [[ "$TRAVIS_BRANCH" = master ]]; then aws s3 cp --acl public-read target/analyst.jar s3://analyst-builds/analysis-latest.jar; fi
 
 # We want to cache the local Maven repo and PIP directories.
 # The Maven dependencies and plugins take a long time to download, as does AWSCLI which is installed via PIP.
@@ -42,4 +38,3 @@ cache:
   - $HOME/.m2
   - $HOME/.local
   - $HOME/.cache/pip
-

--- a/pom.xml
+++ b/pom.xml
@@ -60,26 +60,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- The Jacoco plugin generates code coverage reports during the Maven test phase. -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
I also made installation of PIP on the build machine conditional, only installing it when we are actually uploading a JAR.