### PR TITLE
Test that JARs produced by build are runnable

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -47,9 +47,11 @@ jobs:
         path: ~/.gradle/caches
         key: gradle-caches
     - name: Build and Test
-      run: gradle build --console=plain
+      run: gradle build
+    - name: Ensure shadow JAR is runnable as backend
+      run: gradle testShadowJarRunnable
     - name: Publish to GH Packages
-      run: gradle publish --console=plain
+      run: gradle publish
     - name: Upload to S3
       # Use git describe to get a similar string to the Gradle project version (possibly missing .dirty).
       run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -50,7 +50,7 @@ jobs:
       run: gradle build
     - name: Ensure shadow JAR is runnable as backend
       run: |
-        cp analysis.properties.tmp analysis.properties
+        cp analysis.properties.template analysis.properties
         gradle testShadowJarRunnable
     - name: Publish to GH Packages
       run: gradle publish

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -60,9 +60,9 @@ jobs:
         VERSION=$(gradle -q printVersion | head -n1)
         LOCAL_FILE=$(ls build/libs/*-all.jar | head -n1)
         aws s3 cp --no-progress --region eu-west-1 $LOCAL_FILE s3://r5-builds/${VERSION}.jar
-    # If this run is for the head of a branch, also copy to branch-latest.jar. 'aws s3 cp' will overwrite by default.
+    # If we are on the head of dev or master, also copy to branch-latest.jar. 'aws s3 cp' will overwrite by default.
     - name: Copy to branch-latest.jar on S3
-      if: startsWith(github.ref, 'refs/heads/')
+      if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master'
       run: |
         VERSION=$(gradle -q printVersion | head -n1)
         BRANCH=${GITHUB_REF#refs/heads/}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -49,7 +49,9 @@ jobs:
     - name: Build and Test
       run: gradle build
     - name: Ensure shadow JAR is runnable as backend
-      run: gradle testShadowJarRunnable
+      run: |
+        cp analysis.properties.tmp analysis.properties
+        gradle testShadowJarRunnable
     - name: Publish to GH Packages
       run: gradle publish
     - name: Upload to S3

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,19 @@
 .gradle/
-build/
+/build/
+/out/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# IntelliJ IDEA
+.idea/
+
 logs
 project/project
 project/target

--- a/analysis.properties.template
+++ b/analysis.properties.template
@@ -1,12 +1,4 @@
-# This file contains the configuration options for Conveyal Analysis
-
-# Auth0 authentication configuration. The values will be ignored when configuration option offline=true.
-auth0-client-id=X
-auth0-domain=auth.domain.com
-auth0-secret=Y
-
-# Access group for administrators
-admin-access-group=OFFLINE
+# This file contains the configuration options for Conveyal Analysis Backend
 
 # The host and port of the remote Mongo server (if any). Comment out for local Mongo instance.
 # database-uri=mongodb://127.0.0.1:27017
@@ -17,15 +9,13 @@ database-name=analysis
 # The URL where the frontend is hosted.
 # In production this should point to a cached CDN for speed. e.g. https://d1uqjuy3laovxb.cloudfront.net
 # In staging this should be the underlying S3 URL so files are not cached and you see the most recent deployment.
-frontend-url=https://scenario-editor-staging.s3.amazonaws.com
+frontend-url=https://localhost
 
 # S3 buckets where Analysis inputs and results are stored.
 bundle-bucket=analysis-staging-bundles
 grid-bucket=analysis-staging-grids
 results-bucket=analysis-staging-results
-
-# The URL from which Analysis can fetch OSM extracts on demand using Conveyal Vanilla Extract.
-vex-url=http://osm.conveyal.com/vex
+resources-bucket=analysis-staging-resources
 
 # The S3 bucket where we can find tiles of the entire US census, built with Conveyal seamless-census.
 seamless-census-bucket=lodes-data-2014
@@ -57,30 +47,3 @@ heavy-threads=3
 # This limit doesn't work very well because if you've manually started 200 workers on one graph,
 # the broker then won't start more workers for a completely different job.
 max-workers=8
-
-# IAM role to assign the worker instances. Currently this is the same role assigned to the backend/broker.
-# This is the IAM role whose policy is defined in iam.yml (and is recursively referenced therein).
-worker-iam-role=arn:aws:iam::abcdef123456
-
-# Type of EC2 instance to start up, in the standard AWS format containing a dot as listed on
-# https://aws.amazon.com/ec2/instance-types/
-worker-type=r5.xlarge
-
-# The AWS Cloudwatch log group for worker EC2 instances.
-# Each worker creates its own log stream within this log group at startup.
-worker-log-group=123456abcdef
-
-# The port on which the workers will listen for high priority pushed tasks.
-# This should be different from the server-port if you want to run a worker on the same machine as the server.
-worker-port=7080
-
-# The ID of the AWS VPC subnet where EC2 worker instances will run.
-# Currently this is the same subnet where the backend and broker run.
-# The CIDR mask of this subnet naturally limits the number of workers, providing
-# some level of protection against high EC2 bills should workers accidentally proliferate.
-worker-subnet-id=subnet-123456abcdef
-
-# The ID of the EC2 machine image for the workers. We use a stock Amazon Linux instance and perform additional
-#installation and configuration on startup using a user-data script.
-worker-ami-id=ami-e5083683
-

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
+// Create a configuration properties file (by copying the template) before running this task.
 task testShadowJarRunnable(type: JavaExec) {
     dependsOn(shadowJar)
     classpath(shadowJar.archiveFile.get())

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,13 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
+task testShadowJarRunnable(type: JavaExec) {
+    dependsOn(shadowJar)
+    classpath(shadowJar.archiveFile.get())
+    main("com.conveyal.analysis.BackendMain")
+    jvmArgs("-Dconveyal.immediate.shutdown=true")
+}
+
 // Create a properties file so Java code can be aware of its own version. Properties allow exposing multiple values
 // such as the full commit ID and branch name, rather than just the version available in the JAR manifest.
 task createVersionProperties(dependsOn: processResources) {

--- a/src/main/java/com/conveyal/analysis/BackendConfig.java
+++ b/src/main/java/com/conveyal/analysis/BackendConfig.java
@@ -64,6 +64,10 @@ public class BackendConfig implements
     private final int heavyThreads;
     private final int maxWorkers;
 
+    // If set to true, the backend will start up and immediately exit with a success code.
+    // This is used for testing that automated builds and JAR packaging are producing a usable artifact.
+    public final boolean immediateShutdown;
+
     // For use in testing - setting this field will activate alternate code paths that cause intentional failures.
     private boolean testTaskRedelivery = false;
 
@@ -98,6 +102,7 @@ public class BackendConfig implements
 
         // We intentionally don't supply any defaults here - any 'defaults' should be shipped in an example config file.
         autoShutdown = Boolean.parseBoolean(getProperty("auto-shutdown", false));
+        immediateShutdown = Boolean.parseBoolean(getProperty("immediate-shutdown", false));
         bundleBucket = getProperty("bundle-bucket", true);
         databaseName = getProperty("database-name", true);
         databaseUri = getProperty("database-uri", false);

--- a/src/main/java/com/conveyal/analysis/BackendConfig.java
+++ b/src/main/java/com/conveyal/analysis/BackendConfig.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -41,8 +42,10 @@ public class BackendConfig implements
 
     public static final String PROPERTIES_FILE_NAME = "analysis.properties";
 
-    protected Properties config = new Properties();
-    protected Set<String> missingKeys = new HashSet<>();
+    public static final String CONVEYAL_PROPERTY_PREFIX = "conveyal-";
+
+    protected final Properties config = new Properties();
+    protected final Set<String> missingKeys = new HashSet<>();
 
     // If true, this backend instance should shut itself down after a period of inactivity.
     public final boolean autoShutdown;
@@ -64,21 +67,34 @@ public class BackendConfig implements
     // For use in testing - setting this field will activate alternate code paths that cause intentional failures.
     private boolean testTaskRedelivery = false;
 
+    /**
+     * Construct a backend configuration object from the default non-testing properties file.
+     */
     public BackendConfig () {
-        // Use default non-testing properties file.
         this(PROPERTIES_FILE_NAME);
     }
 
+    /**
+     * Load configuration from the given properties file, overriding from environment variables and system properties.
+     * In the latter two sources, the keys may be in upper or lower case and use dashes, underscores, or dots as
+     * separators. The usual config file keys must be prefixed with "conveyal", e.g. CONVEYAL_HEAVY_THREADS=5 or
+     * conveyal.heavy.threads=5.
+     * Precedence of configuration sources is: system properties > environment variables > config file.
+     */
     public BackendConfig (String filename) {
-        try {
-            FileInputStream is = new FileInputStream(filename);
+        try (FileInputStream is = new FileInputStream(filename)) {
             config.load(is);
-            is.close();
         } catch (Exception e) {
             String message = "Could not read config file " + filename;
             LOG.error(message);
             throw new RuntimeException(message, e);
         }
+
+        // Overwrite properties from config file with environment variables and system properties.
+        // This could also be done with the Properties constructor that specifies defaults, but by manually
+        // overwriting items we are able to log these potentially confusing changes to configuration.
+        setPropertiesFromMap(System.getenv(), "environment variable");
+        setPropertiesFromMap(System.getProperties(), "system properties");
 
         // We intentionally don't supply any defaults here - any 'defaults' should be shipped in an example config file.
         autoShutdown = Boolean.parseBoolean(getProperty("auto-shutdown", false));
@@ -99,6 +115,29 @@ public class BackendConfig implements
         if (!missingKeys.isEmpty()) {
             LOG.error("You must provide these configuration properties: {}", String.join(", ", missingKeys));
             System.exit(1);
+        }
+    }
+
+    /**
+     * This needs to work with both properties and environment variable conventions, so case and separators
+     * are normalized. Properties are Object-Object Maps so key and value are cast to String.
+     */
+    private void setPropertiesFromMap (Map<?, ?> map, String sourceDescription) {
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            // Normalize to String type, all lower case, all dash separators.
+            String key = ((String)entry.getKey()).toLowerCase().replaceAll("[\\._-]", "-");
+            String value = ((String)entry.getValue());
+            if (key.startsWith(CONVEYAL_PROPERTY_PREFIX)) {
+                // Strip off conveyal prefix to get the key that would be used in our config file.
+                key = key.substring(CONVEYAL_PROPERTY_PREFIX.length());
+                String existingKey = config.getProperty(key);
+                if (existingKey != null) {
+                    LOG.info("Overwriting existing config key {} to '{}' from {}.", key, value, sourceDescription);
+                } else {
+                    LOG.info("Setting configuration key {} to '{}' from {}.", key, value, sourceDescription);
+                }
+                config.setProperty(key, value);
+            }
         }
     }
 

--- a/src/main/java/com/conveyal/analysis/BackendMain.java
+++ b/src/main/java/com/conveyal/analysis/BackendMain.java
@@ -44,6 +44,17 @@ public abstract class BackendMain {
     }
 
     protected static void startServer (Components components, Thread... postStartupThreads) {
+        // We have several non-daemon background thread pools which will keep the JVM alive if the main thread crashes.
+        // If initialization fails, we need to catch the exception or error and force JVM shutdown.
+        try {
+            startServerInternal(components, postStartupThreads);
+        } catch (Throwable throwable) {
+            LOG.error("Exception while starting up backend, shutting down JVM.\n{}", ExceptionUtils.asString(throwable));
+            System.exit(1);
+        }
+    }
+
+    private static void startServerInternal (Components components, Thread... postStartupThreads) {
         LOG.info("Starting Conveyal analysis backend, the time is now {}", DateTime.now());
         LOG.info("Backend version is: {}", BackendVersion.instance.version);
         LOG.info("Connecting to database...");

--- a/src/main/java/com/conveyal/analysis/BackendMain.java
+++ b/src/main/java/com/conveyal/analysis/BackendMain.java
@@ -71,6 +71,11 @@ public abstract class BackendMain {
             thread.start();
         }
 
+        if (components.config.immediateShutdown) {
+            LOG.info("Startup has completed successfully. Exiting immediately as requested.");
+            System.exit(0);
+        }
+
         // TODO transform this into a task managed by a scheduled task executor component.
         if (components.config.autoShutdown) {
             LOG.info("Server will shut down automatically after {} minutes without user interaction.", IDLE_SHUTDOWN_MINUTES);

--- a/src/main/java/com/conveyal/r5/util/ExceptionUtils.java
+++ b/src/main/java/com/conveyal/r5/util/ExceptionUtils.java
@@ -4,15 +4,15 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 /**
- * Convenience functions for working with exceptions.
+ * Convenience functions for working with exceptions (or more generally throwables).
  */
 public abstract class ExceptionUtils {
 
-    public static String asString(Exception exception) {
+    public static String asString(Throwable throwable) {
         StringWriter sw = new StringWriter();
-        sw.append(exception.getMessage());
+        sw.append(throwable.getMessage());
         sw.append("\n");
-        exception.printStackTrace(new PrintWriter(sw));
+        throwable.printStackTrace(new PrintWriter(sw));
         return sw.toString();
     }
 


### PR DESCRIPTION
This PR tests that the shadow JAR produced by the Github Actions build can actually be run without crashing.

There is a new config property "immediate-shutdown" which defaults to false, but if set to true will cause the JVM to exit with a success code as soon as our backend finishes starting up. Any errors that occur during startup are trapped and cause a JVM shutdown with a failure exit code.

To enable this, you can now set Conveyal backend configuration options via environment variables or the JVM command line. Our usual config properties are prefixed with "conveyal" in this context: system properties are specified on the JVM command line with `-Dconveyal.config.key=value`
and environment variables are specified as `CONVEYAL_CONFIG_KEY=value`.

