### PR TITLE
Fix JAI / ImageIO initialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,13 @@ jar {
         attributes 'Automatic-Module-Name': 'com.conveyal.analysis',
                    'Main-Class': 'com.conveyal.r5.R5Main',
                    'Implementation-Title': 'Conveyal Analysis Backend',
-                   'Implementation-Version': project.version
+                   'Implementation-Version': project.version,
+                   'Implementation-Vendor': 'Conveyal LLC',
+                   // Metadata to satisfy Java Advanced Imaging (why is this not merged from its JAR?)
+                   'Specification-Title': 'Java Advanced Imaging Image I/O Tools',
+                   'Specification-Version': '1.1',
+                   'Specification-Vendor': 'Sun Microsystems, Inc.',
+                   'Extension-Name': 'com.sun.media.imageio'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,21 +18,11 @@ jar {
     // For Java 11 Modules, specify a module name.
     // Do not create module-info.java until all our dependencies specify a module name.
     // Main-Class R5Main will start a worker, BackendMain must be specified on JVM command line to start backend.
-    // Store the build version in the JAR manifest
-    // to allow using it in Java code with X.class.getPackage().getImplementationVersion()
     manifest {
         attributes 'Automatic-Module-Name': 'com.conveyal.analysis',
                    'Main-Class': 'com.conveyal.r5.R5Main',
-                   'Implementation-Title': 'Conveyal Analysis Backend',
-                   'Implementation-Version': project.version,
-                   'Implementation-Vendor': 'Conveyal LLC',
-                   // Mimic Maven manifest entry that helps with automated installation of the right JVM
-                   'Build-Jdk-Spec': targetCompatibility.getMajorVersion(),
-                   // Metadata to satisfy Java Advanced Imaging (why is this not merged from its JAR?)
-                   'Specification-Title': 'Java Advanced Imaging Image I/O Tools',
-                   'Specification-Version': '1.1',
-                   'Specification-Vendor': 'Sun Microsystems, Inc.',
-                   'Extension-Name': 'com.sun.media.imageio'
+                   // Mimic Maven manifest entry that helps automatically install the right JVM
+                   'Build-Jdk-Spec': targetCompatibility.getMajorVersion()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,11 @@ plugins {
 group = 'com.conveyal'
 // set version to `git describe --tags --always --first-parent`, plus '.dirty' if local changes are present.
 version gitVersion()
-sourceCompatibility = '11'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 jar {
     // For Java 11 Modules, specify a module name.
@@ -22,6 +26,8 @@ jar {
                    'Implementation-Title': 'Conveyal Analysis Backend',
                    'Implementation-Version': project.version,
                    'Implementation-Vendor': 'Conveyal LLC',
+                   // Mimic Maven manifest entry that helps with automated installation of the right JVM
+                   'Build-Jdk-Spec': targetCompatibility.getMajorVersion(),
                    // Metadata to satisfy Java Advanced Imaging (why is this not merged from its JAR?)
                    'Specification-Title': 'Java Advanced Imaging Image I/O Tools',
                    'Specification-Version': '1.1',

--- a/src/main/java/com/conveyal/analysis/BackendMain.java
+++ b/src/main/java/com/conveyal/analysis/BackendMain.java
@@ -16,7 +16,6 @@ import spark.Request;
 import spark.Response;
 import spark.Spark;
 
-import javax.imageio.ImageIO;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -58,9 +57,6 @@ public abstract class BackendMain {
         LOG.info("Starting Conveyal analysis backend, the time is now {}", DateTime.now());
         LOG.info("Backend version is: {}", BackendVersion.instance.version);
         LOG.info("Connecting to database...");
-
-        // Initialize ImageIO. See http://stackoverflow.com/questions/20789546
-        ImageIO.scanForPlugins();
 
         // Persistence, the census extractor, and ApiMain are initialized statically, without creating instances,
         // passing in non-static components we've already created. TODO migrate to non-static Components.


### PR DESCRIPTION
We were manually initializing ImageIO, which is part of Java Advanced Imaging -- old, unmaintained, and originally closed-source Oracle code. Geotools used to depend on this, but has migrated to a newer completely open source implementation of this API called JAI-Ext. See https://www.geosolutionsgroup.com/blog/developers-corner-jai-ext-the-open-source-replacement-for-oracle-jai/

This ImageIO initialization process depended on a bunch of metadata in the JAR manifest that we had to inject in our build, since it was not being preserved by the shadow-jar process. But I could see that there was similar initialization code floating around in our dependencies that would not check the manifest: it had all the attributes JAI used to load from the manifest hard-coded.

Removing the call to `ImageIO.scanForPlugins()` and instead calling `JAIExt.initJAIEXT()`, there were no longer any failures even when the attributes were left out of the Manifest. The backend was nonetheless capable of writing a GeoTIFF. But in fact, even removing `JAIExt.initJAIEXT()` it is still able to write a GeoTIFF. The GeoTools writer now seems to use ImageIOExt directly instead of the original ImageIO. It appears that no scanning is needed now, or that scanning is already done by Geotools.

I have tested exports of TIFF and PNG files and everything seems to work fine with no ImageIO initialization.

This also records the target JVM version in the JAR Manifest, which was causing the worker failure @ansoncfit mentioned in the same issue. I have tested the resulting worker version `v5.10.0-10-g6a0f9c7` on production. The worker is able to detect the right JVM version, and starts up properly.

