### PR TITLE
Detect updated stops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,12 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
+// A task to copy all dependencies of the project into a single directory
+task copyDependencies(type: Copy) {
+    from configurations.default
+    into 'dependencies'
+}
+
 // Create a configuration properties file (by copying the template) before running this task.
 task testShadowJarRunnable(type: JavaExec) {
     dependsOn(shadowJar)

--- a/src/main/java/com/conveyal/r5/common/Util.java
+++ b/src/main/java/com/conveyal/r5/common/Util.java
@@ -1,8 +1,7 @@
 package com.conveyal.r5.common;
 
-/**
- * Created by abyrd on 2017-11-29
- */
+import java.util.Arrays;
+
 public abstract class Util {
 
     public static String human (double n, String units) {
@@ -24,6 +23,13 @@ public abstract class Util {
             prefix = "Ti";
         }
         return String.format("%1.1f %s%s", n, prefix, units);
+    }
+
+    /** Convenience method to create an array and fill it immediately with a single value. */
+    public static int[] newIntArray (int length, int defaultValue) {
+        int[] array = new int[length];
+        Arrays.fill(array, defaultValue);
+        return array;
     }
 
 }

--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -511,26 +511,21 @@ public class FastRaptorWorker {
                 ) {
                     int earliestBoardTime = inputState.bestTimes[stop] + MINIMUM_BOARD_WAIT_SEC;
                     if (onTrip == -1) {
-                        if (inputState.stopWasUpdated(stop)) { // FIXME due to enclosing conditional this is always true.
-                            int candidateTripIndex = -1;
-                            EARLIEST_TRIP:
-                            for (TripSchedule candidateSchedule : pattern.tripSchedules) {
-                                candidateTripIndex++;
-
-                                if (!servicesActive.get(candidateSchedule.serviceCode) || candidateSchedule.headwaySeconds != null) {
-                                    // frequency trip or not running
-                                    continue;
-                                }
-
-                                if (earliestBoardTime < candidateSchedule.departures[stopPositionInPattern]) {
-                                    // board this vehicle
-                                    onTrip = candidateTripIndex;
-                                    schedule = candidateSchedule;
-                                    boardTime = candidateSchedule.departures[stopPositionInPattern];
-                                    waitTime = boardTime - inputState.bestTimes[stop];
-                                    boardStop = stop;
-                                    break EARLIEST_TRIP;
-                                }
+                        int candidateTripIndex = -1;
+                        for (TripSchedule candidateSchedule : pattern.tripSchedules) {
+                            candidateTripIndex++;
+                            if (!servicesActive.get(candidateSchedule.serviceCode) || candidateSchedule.headwaySeconds != null) {
+                                // frequency trip or not running
+                                continue;
+                            }
+                            if (earliestBoardTime < candidateSchedule.departures[stopPositionInPattern]) {
+                                // board this vehicle
+                                onTrip = candidateTripIndex;
+                                schedule = candidateSchedule;
+                                boardTime = candidateSchedule.departures[stopPositionInPattern];
+                                waitTime = boardTime - inputState.bestTimes[stop];
+                                boardStop = stop;
+                                break;
                             }
                         }
                     } else {

--- a/src/main/java/com/conveyal/r5/profile/FrequencyRandomOffsets.java
+++ b/src/main/java/com/conveyal/r5/profile/FrequencyRandomOffsets.java
@@ -47,6 +47,11 @@ public class FrequencyRandomOffsets {
         }
     }
 
+     /**
+      * Take a new Monte Carlo draw if requested (i.e. if boarding assumption is not half-headway): for each
+      * frequency-based route, choose how long after service starts the first vehicle leaves (the route's "phase").
+      * We run all Raptor rounds with one draw before proceeding to the next draw.
+      */
     public void randomize () {
         int remaining = 0;
 

--- a/src/main/java/com/conveyal/r5/profile/RaptorState.java
+++ b/src/main/java/com/conveyal/r5/profile/RaptorState.java
@@ -168,11 +168,8 @@ public class RaptorState {
     }
 
     /**
-     * Makes a deep copy of this raptor state, clearing the sets of reached stops and setting the new state's previous
-     * pointer to this existing state.
-     *
-     * FIXME this seems designed for progressing to the next round, but is only used for starting frequency searches.
-     *       it should probably set the previous pointer to null.
+     * Makes a deep copy of this raptor state. Everything is replicated, except the sets of stops updated in this round
+     * (which are cleared) and the reference to the previous round's state (which is nulled out).
      */
     public RaptorState copy () {
         return new RaptorState(this);

--- a/src/main/java/com/conveyal/r5/profile/RaptorState.java
+++ b/src/main/java/com/conveyal/r5/profile/RaptorState.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.BitSet;
 
+import static com.conveyal.r5.common.Util.newIntArray;
 import static com.conveyal.r5.profile.FastRaptorWorker.UNREACHED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -121,24 +122,27 @@ public class RaptorState {
      * Travel times to all stops are initialized to UNREACHED, which will be improved upon by the search process.
      */
     public RaptorState (int nStops, int maxDurationSeconds) {
-        this.bestTimes = new int[nStops];
-        this.bestNonTransferTimes = new int[nStops];
+        this.maxDurationSeconds = maxDurationSeconds;
 
-        Arrays.fill(bestTimes, UNREACHED);
-        Arrays.fill(bestNonTransferTimes, UNREACHED);
+        // Array slot for every stop is initialized to the maximum integer value, which the search will improve upon.
+        this.bestTimes = newIntArray(nStops, UNREACHED);
+        this.bestNonTransferTimes = newIntArray(nStops, UNREACHED);
 
-        this.previousPatterns = new int[nStops];
-        this.previousStop = new int[nStops];
-        this.transferStop = new int[nStops];
-        Arrays.fill(previousPatterns, -1);
-        Arrays.fill(previousStop, -1);
-        Arrays.fill(transferStop, -1);
+        // Initialized to contain all -1, indicating "none".
+        this.previousPatterns = newIntArray(nStops, -1);
+        this.previousStop = newIntArray(nStops, -1);
+        this.transferStop = newIntArray(nStops, -1);
 
+        // These fields accumulate times, so are initially filled with zeros.
         this.nonTransferWaitTime = new int[nStops];
         this.nonTransferInVehicleTravelTime = new int[nStops];
+
+        // Empty sets that will track the stops that have been updated in this round.
         this.nonTransferStopsTouched = new BitSet(nStops);
         this.bestStopsTouched = new BitSet(nStops);
-        this.maxDurationSeconds = maxDurationSeconds;
+
+        // Previous round reference should be set as needed by the code calling this constructor.
+        this.previous = null;
     }
 
     /**


### PR DESCRIPTION
The core change here is in 6429fad, which removes the updated stops sets from raptor state objects and replaces them with instance methods that determine on the fly whether a particular stop has been updated since the last round. This seems significantly less complex than maintaining independent updated stops sets as we progress through the departure minutes, then as we progress through the randomized schedules and rounds. This approach may even be more efficient, because it accesses the same contiguous arrays of travel times that are already heavily accessed by adjacent code, and often does so sequentially across all stops.

All other commits in this PR are refactors that improve maintainability, readability, or testability without affecting output.
