### PR TITLE
Track updated stops separately within and across departure minutes

### DIFF
--- a/src/main/java/com/conveyal/r5/profile/ExecutionTimer.java
+++ b/src/main/java/com/conveyal/r5/profile/ExecutionTimer.java
@@ -18,6 +18,9 @@ import static com.google.common.base.Preconditions.checkState;
  * sub-millisecond in duration. (Arguably on large numbers of operations using msec would be fine because the number of
  * times we cross a millisecond boundary would be proportional to the portion of a millisecond that operation took, but
  * nanoTime() avoids the problem entirely.)
+ *
+ * TODO ability to dump to JSON or JsonNode tree for inclusion in response, via some kind of request-scoped context
+ *  object. This should help enable continuous performance tracking in CI.
  */
 public class ExecutionTimer {
 

--- a/src/main/java/com/conveyal/r5/profile/ExecutionTimer.java
+++ b/src/main/java/com/conveyal/r5/profile/ExecutionTimer.java
@@ -67,9 +67,14 @@ public class ExecutionTimer {
         return String.format("%s: %s", name, description);
     }
 
+    /** Root timer is logged at INFO level, and details of children at DEBUG level. */
     public void log (int indentLevel) {
-        String indent = Strings.repeat("- ", indentLevel);
-        LOG.debug(indent + this.getMessage());
+        if (indentLevel == 0) {
+            LOG.info(getMessage());
+        } else {
+            String indent = Strings.repeat("- ", indentLevel);
+            LOG.debug(indent + getMessage());
+        }
     }
 
     public void logWithChildren () {

--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -859,9 +859,13 @@ public class FastRaptorWorker {
 
     /**
      * Find all patterns that could lead to improvements in the next round after the given state's raptor round.
-     * Specifically, the patterns passing through all stops that were updated in the given state's round.
+     * Specifically, the patterns passing through all stops that were updated in the given state's round. 
+     * For frequency upper-bound and schedule searches, no previously checked (i.e. later) departure time can yield 
+     * earlier arrival times at stops, so only patterns passing through stops updated in this round need to be checked in the next round. 
+     * For frequency searches, where the randomized schedules vary, a previously checked departure minute could lead to an
+     * earlier arrival, so the incumbent best arrival time at each stop needs to be compared directly against the arrival time in this round.
      * The pattern indexes returned are limited to those in the supplied set.
-     * @param withinMinute EXPLAIN
+     * @param withinMinute if true, consider updates only within this round; should be false when previously checked rounds (i.e. later departure minutes) can have earlier arrivals at stops (e.g. in the case of frequency searches with random schedules)
      */
     private BitSet patternsToExploreInNextRound (RaptorState state, BitSet runningPatterns, boolean withinMinute) {
         if (!ENABLE_OPTIMIZATION_UPDATED_STOPS) {

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -108,6 +108,8 @@ public class PerTargetPropagater {
      */
     private Path[] perIterationPaths;
 
+    private final PropagationTimer timer;
+
     /**
      * Constructor.
      */
@@ -128,18 +130,20 @@ public class PerTargetPropagater {
         // If we're making a static site we'll break travel times down into components and make paths.
         // This expects the pathsToStopsForIteration and pathWriter fields to be set separately by the caller.
         this.calculateComponents = task.makeTauiSite;
+        this.timer = new PropagationTimer();
 
         oneToOne = request instanceof RegionalTask && ((RegionalTask) request).oneToOne;
-
         nIterations = travelTimesToStopsForIteration.length;
         nStops = travelTimesToStopsForIteration[0].length;
-        invertTravelTimes();
         nTargets = targets.featureCount();
+        linkedTargets = new ArrayList<>(modes.size());
+
+        timer.fullPropagation.start();
+        timer.transposition.start();
+        invertTravelTimes();
         if (nonTransitTravelTimesToTargets.length != nTargets) {
             throw new IllegalArgumentException("Non-transit travel times must have the same number of entries as there are points.");
         }
-        linkedTargets = new ArrayList<>(modes.size());
-
         for (StreetMode streetMode : modes) {
             LinkedPointSet linkedTargetsForMode = streetLayer.parentNetwork.linkageCache
                     .getLinkage(targets, streetLayer, streetMode);
@@ -148,6 +152,9 @@ public class PerTargetPropagater {
             linkedTargetsForMode.getEgressCostTable().destructivelyTransposeForPropagationAsNeeded();
             linkedTargets.add(linkedTargetsForMode);
         }
+        timer.transposition.stop();
+        // Prevent top-level timer from counting any intervening actions until caller calls propagate()
+        timer.fullPropagation.stop();
     }
 
     /**
@@ -156,7 +163,7 @@ public class PerTargetPropagater {
      */
     public OneOriginResult propagate () {
 
-        long startTimeMillis = System.currentTimeMillis();
+        timer.fullPropagation.start();
 
         // perIterationTravelTimes and perIterationDetails are reused when processing each target.
         perIterationTravelTimes = new int[nIterations];
@@ -189,7 +196,9 @@ public class PerTargetPropagater {
 
             // Improve upon these non-transit travel times based on transit travel times to nearby stops.
             // This fills in perIterationTravelTimes and perIterationPaths for one particular target.
+            timer.propagation.start();
             propagateTransit(targetIdx);
+            timer.propagation.stop();
 
             // Construct the PathScorer before extracting percentiles because the scorer needs to make a copy of
             // the unsorted complete travel times.
@@ -202,7 +211,9 @@ public class PerTargetPropagater {
 
             // Extract the requested percentiles and save them (and/or the resulting accessibility indicator values)
             int targetToWrite = oneToOne ? 0 : targetIdx;
+            timer.reducer.start();
             travelTimeReducer.extractTravelTimePercentilesAndRecord(targetToWrite, perIterationTravelTimes);
+            timer.reducer.stop();
 
             if (calculateComponents) {
                 // TODO Somehow report these in-vehicle, wait and walk breakdown values alongside the total travel time.
@@ -214,9 +225,8 @@ public class PerTargetPropagater {
                 pathWriter.recordPathsForTarget(selectedPaths);
             }
         }
-        LOG.info("Propagating {} iterations from {} stops to {} target points took {}s",
-                nIterations, nStops, endTarget - startTarget, (System.currentTimeMillis() - startTimeMillis) / 1000d
-        );
+        timer.fullPropagation.stop();
+        timer.log();
         if (pathWriter != null) {
             pathWriter.finishAndStorePaths();
         }
@@ -244,14 +254,12 @@ public class PerTargetPropagater {
      * locality problems elsewhere (since the pathfinding algorithm solves one iteration for all stops simultaneously).
      */
     private void invertTravelTimes() {
-        long startTime = System.currentTimeMillis();
         travelTimesToStop = new int[nStops][nIterations];
         for (int iteration = 0; iteration < nIterations; iteration++) {
             for (int stop = 0; stop < nStops; stop++) {
                 travelTimesToStop[stop][iteration] = travelTimesToStopsForIteration[iteration][stop];
             }
         }
-        LOG.info("Travel time matrix transposition took {} msec", System.currentTimeMillis() - startTime);
     }
 
     /**

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -108,7 +108,7 @@ public class PerTargetPropagater {
      */
     private Path[] perIterationPaths;
 
-    private final PropagationTimer timer;
+    private final PropagationTimer timer = new PropagationTimer();
 
     /**
      * Constructor.
@@ -121,17 +121,17 @@ public class PerTargetPropagater {
             int[][] travelTimesToStopsForIteration,
             int[] nonTransitTravelTimesToTargets
     ) {
-        this.maxTravelTimeSeconds = task.maxTripDurationMinutes * SECONDS_PER_MINUTE;
         this.targets = targets;
         this.modes = modes;
         this.request = task;
         this.travelTimesToStopsForIteration = travelTimesToStopsForIteration;
         this.nonTransitTravelTimesToTargets = nonTransitTravelTimesToTargets;
+
         // If we're making a static site we'll break travel times down into components and make paths.
         // This expects the pathsToStopsForIteration and pathWriter fields to be set separately by the caller.
-        this.calculateComponents = task.makeTauiSite;
-        this.timer = new PropagationTimer();
+        calculateComponents = task.makeTauiSite;
 
+        maxTravelTimeSeconds = task.maxTripDurationMinutes * SECONDS_PER_MINUTE;
         oneToOne = request instanceof RegionalTask && ((RegionalTask) request).oneToOne;
         nIterations = travelTimesToStopsForIteration.length;
         nStops = travelTimesToStopsForIteration[0].length;

--- a/src/main/java/com/conveyal/r5/profile/PropagationTimer.java
+++ b/src/main/java/com/conveyal/r5/profile/PropagationTimer.java
@@ -1,0 +1,26 @@
+package com.conveyal.r5.profile;
+
+/**
+ * This groups together all the timers recording execution time of various steps of travel time propagation, which
+ * is performed after the raptor search itself.
+ *
+ * TODO constructor that adds stop and target counts to top level message
+ *         LOG.info("Propagating {} iterations from {} stops to {} target points took {}s",
+ *                 nIterations, nStops, endTarget - startTarget, (System.currentTimeMillis() - startTimeMillis) / 1000d
+ *         );
+ */
+public class PropagationTimer {
+
+    public final ExecutionTimer fullPropagation = new ExecutionTimer("Full travel time propagation");
+
+    public final ExecutionTimer transposition = new ExecutionTimer(fullPropagation, "Travel time matrix transposition");
+
+    public final ExecutionTimer propagation = new ExecutionTimer(fullPropagation, "Propagation");
+
+    public final ExecutionTimer reducer = new ExecutionTimer(fullPropagation, "Travel time reducer");
+
+    public void log () {
+        fullPropagation.logWithChildren();
+    }
+
+}

--- a/src/main/java/com/conveyal/r5/profile/RaptorState.java
+++ b/src/main/java/com/conveyal/r5/profile/RaptorState.java
@@ -310,8 +310,8 @@ public class RaptorState {
         // a separate code path, and in fact does not apply the range raptor optimization.
         checkState(additionalWaitSeconds == 60, "Departure times may only be decremented by one minute.");
         this.departureTime = departureTime;
-        this.stopsUpdated.clear();
-        this.nonTransferStopsUpdated.clear();
+        stopsUpdated.clear();
+        nonTransferStopsUpdated.clear();
         // Remove trips that exceed the maximum trip duration when the rider departs earlier (due to more wait time).
         // This whole loop does not seem strictly necessary. In testing, removing it does not change results since
         // real travel times and INF can both compare greater than a cutoff. In fact multi-cutoff depends on this being

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,5 +14,6 @@
 
     <logger name="com.conveyal.osmlib" level="INFO" />
     <logger name="com.conveyal.gtfs" level="INFO" />
+    <logger name="com.conveyal.r5.profile.ExecutionTimer" level="INFO"/>
 
 </configuration>


### PR DESCRIPTION
The scheduled search and upper bound search benefit from tracking which stops were updated within the current departure minute (or randomized schedule), rather than in the previously evaluated departure minutes. In fact, if we don't do this the range raptor optimization is ineffective. But frequency routes must look at the combined effects of all departure minutes - the frequency route's schedule will have changed in each search, but it may be reached by a scheduled ride that was found in a different departure minute.

This PR builds on #269, aiming to produce results identical to v5.10.1 (accounting for frequency search requirements described above) but regaining the range-raptor speedup. Limited speed testing was done on a medium-sized network, with a scenario adding frequency routes and 500 Monte Carlo draws. Enabling range raptor in this PR gives "only" a 30% speedup over using fresh state at each departure minute, but even without range raptor enabled this new branch is already 68% faster than v5.10.1. So total speedup over v5.10.1 is about 77%, while apparently maintaining identical results. Non-frequency results are obtained just as fast as v5.10.0, and high-draw frequency results are obtained in about 2.25x as long as v5.10.0 (but seem to match the results from v5.10.1, which takes over 4x as long as v5.10.0). 

To confirm that results are equivalent, I have run regional analyses in large networks with many low frequency routes added in scenarios. Comparing single-point results between this PR and the tagged v5.10.1, there is practically no difference in travel times and accessibility curves, even at origin points that previously showed noticeable errors in v5.10.0.

Comparing regional analyses, the new version produces identical baseline results to v5.10.0 and v5.10.1. Regional scenario results with added frequency routes show differences in cumulative accessibility that are almost zero everywhere relative to v5.10.1, except in cells with only a few hundred accessible people, which are easily skewed by a few seconds' variation in randomized schedules.
